### PR TITLE
Handle modifiers and annotations in Java regex parser

### DIFF
--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/engine/JavaRegexParser.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/engine/JavaRegexParser.kt
@@ -17,19 +17,23 @@ class JavaRegexParser : JavaScanner {
         if (!packagePrefix.isNullOrBlank() && pkg.isNotBlank() && !pkg.startsWith(packagePrefix)) {
             return emptyList()
         }
-        val classRegex = Pattern.compile("(?m)^\\s*(public|protected|private)?\\s*(final|abstract|static)?\\s*class\\s+([A-Za-z0-9_]+)")
+        val classRegex = Pattern.compile(
+            "(?m)^\\s*(?:@[\\w$.]+(?:\\([^)]*\\))?\\s*)*(?:(?:\\b(?:public|protected|private|abstract|final|static|strictfp|sealed)\\b|non-sealed)\\s+)*class\\s+([A-Za-z0-9_]+)"
+        )
         val classMatcher = classRegex.matcher(text)
         while (classMatcher.find()) {
-            val className = classMatcher.group(3)
+            val className = classMatcher.group(1)
             val fqcn = if (pkg.isBlank()) className else "$pkg.$className"
             val openIndex = text.indexOf('{', classMatcher.end())
             if (openIndex < 0) continue
             val closeIndex = findMatchingBrace(text, openIndex)
             val bodyText = text.substring(openIndex + 1, closeIndex)
-            val methodRegex = Pattern.compile("(?m)^\\s*(public|protected|private)?\\s*(static\\s+)?[\\w<>\\[\\]]+\\s+([a-zA-Z0-9_]+)\\s*\\(([^)]*)\\)\\s*\\{")
+            val methodRegex = Pattern.compile(
+                "(?m)^\\s*(?:@[\\w$.]+(?:\\([^)]*\\))?\\s*)*(?:(?:\\b(?:public|protected|private|abstract|final|static|strictfp|synchronized|native|default)\\b)\\s+)*(?:<[^>]+>\\s*)?[\\w$<>\\[\\],.?\\s]+\\s+([a-zA-Z0-9_]+)\\s*\\(([^)]*)\\)\\s*\\{"
+            )
             val methodMatcher = methodRegex.matcher(bodyText)
             while (methodMatcher.find()) {
-                val methodName = methodMatcher.group(3)
+                val methodName = methodMatcher.group(1)
                 val methodStartInClass = openIndex + 1 + methodMatcher.start()
                 val methodOpen = text.indexOf('{', methodStartInClass)
                 if (methodOpen < 0) continue

--- a/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/engine/JavaRegexParserTest.kt
+++ b/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/engine/JavaRegexParserTest.kt
@@ -1,0 +1,72 @@
+package de.burger.forensics.plugin.engine
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class JavaRegexParserTest {
+    private val parser = JavaRegexParser()
+
+    @Test
+    fun `scan handles annotated classes and methods`() {
+        val javaSource = """
+            package com.example;
+
+            @Deprecated
+            public final class SampleService {
+                @Override
+                public synchronized String execute(String input) {
+                    if (input == null) {
+                        return \"fallback\";
+                    }
+                    return input;
+                }
+            }
+        """.trimIndent()
+
+        val rules = parser.scan(
+            text = javaSource,
+            helperFqn = "helper.Fqn",
+            packagePrefix = "com.example",
+            includeEntryExit = true,
+            maxStringLength = 200
+        )
+
+        assertTrue(rules.any { it.contains("RULE enter@com.example.SampleService.execute") })
+        assertTrue(rules.any { it.contains("RULE com.example.SampleService.execute:") && it.contains(":if-true") })
+        assertTrue(rules.any { it.contains("RULE com.example.SampleService.execute:") && it.contains(":if-false") })
+        assertTrue(rules.any { it.contains("RULE exit@com.example.SampleService.execute") })
+    }
+
+    @Test
+    fun `scan handles repeated modifiers on nested classes`() {
+        val javaSource = """
+            package com.example;
+
+            public class Outer {
+                public static final class InnerHelper {
+                    @SafeVarargs
+                    public static final <T> void process(T... items) {
+                        switch (items.length) {
+                            case 0:
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val rules = parser.scan(
+            text = javaSource,
+            helperFqn = "helper.Fqn",
+            packagePrefix = "com.example",
+            includeEntryExit = true,
+            maxStringLength = 200
+        )
+
+        assertTrue(rules.any { it.contains("RULE enter@com.example.InnerHelper.process") })
+        assertTrue(rules.any { it.contains("RULE com.example.InnerHelper.process:") && it.contains(":when") })
+        assertTrue(rules.any { it.contains("RULE com.example.InnerHelper.process:") && it.contains(":case") })
+    }
+}


### PR DESCRIPTION
## Summary
- broaden the Java class and method regular expressions to tolerate repeated modifiers and annotations
- add unit coverage to ensure annotated and heavily-modified classes and methods emit byteman rules

## Testing
- ./gradlew test *(fails: gradle-wrapper.jar missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d6eeae16948326a5afca46752d4ac4