### PR TITLE
Ensure deterministic Java rule order with parallel generation

### DIFF
--- a/forensics-btmgen/build.gradle.kts
+++ b/forensics-btmgen/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.2.0")
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
+    testImplementation(gradleTestKit())
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
     add("functionalTestImplementation", "org.junit.jupiter:junit-jupiter-api:5.10.2")
     add("functionalTestImplementation", gradleTestKit())

--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/GenerateBtmTask.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/GenerateBtmTask.kt
@@ -264,11 +264,18 @@ abstract class GenerateBtmTask : DefaultTask() {
             val scanner = JavaRegexParser()
             // Simple parallelism for Java files only
             val par = parallelism.getOrElse(1)
-            val stream = if (par > 1) javaSourceFiles.parallelStream() else javaSourceFiles.stream()
-            stream.forEach { file ->
-                val text = file.readText()
-                val fileRules = scanner.scan(text, helper, legacyPrefix, includeEntryExit, maxLen)
-                synchronized(rules) { rules += fileRules }
+            if (par > 1) {
+                javaSourceFiles.parallelStream().forEachOrdered { file ->
+                    val text = file.readText()
+                    val fileRules = scanner.scan(text, helper, legacyPrefix, includeEntryExit, maxLen)
+                    synchronized(rules) { rules += fileRules }
+                }
+            } else {
+                javaSourceFiles.forEach { file ->
+                    val text = file.readText()
+                    val fileRules = scanner.scan(text, helper, legacyPrefix, includeEntryExit, maxLen)
+                    rules += fileRules
+                }
             }
         }
 

--- a/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/GenerateBtmTaskTest.kt
+++ b/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/GenerateBtmTaskTest.kt
@@ -1,0 +1,77 @@
+package de.burger.forensics.plugin
+
+import org.gradle.testfixtures.ProjectBuilder
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GenerateBtmTaskTest {
+
+    @Test
+    fun `java rules remain stable with parallelism`() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("generateBtmTest", GenerateBtmTask::class.java).get()
+
+        val sourceDir = Files.createTempDirectory("btmgen-java-src").toFile()
+        val slowSource = buildString {
+            appendLine("package com.example;")
+            appendLine("public class Alpha {")
+            appendLine("    public void slow(int value) {")
+            repeat(2_000) { idx ->
+                appendLine("        if (value == $idx) { System.out.println($idx); }")
+            }
+            appendLine("    }")
+            appendLine("}")
+        }
+        File(sourceDir, "Alpha.java").writeText(slowSource)
+
+        val fastSource = """
+            package com.example;
+
+            public class Beta {
+                public void fast(int value) {
+                    if (value == 0) {
+                        System.out.println(value);
+                    }
+                }
+            }
+        """.trimIndent()
+        File(sourceDir, "Beta.java").writeText(fastSource)
+
+        task.srcDirs.set(listOf(sourceDir.absolutePath))
+        task.packagePrefix.set("com.example")
+        task.helperFqn.set("helper.Helper")
+        task.entryExit.set(true)
+        task.trackedVars.set(emptyList())
+        task.includeJava.set(true)
+        task.includeTimestamp.set(false)
+        task.maxStringLength.set(200)
+        task.pkgPrefixes.set(emptyList())
+        task.includePatterns.set(emptyList())
+        task.excludePatterns.set(emptyList())
+        task.parallelism.set(4)
+        task.shardOutput.set(1)
+        task.gzipOutput.set(false)
+        task.minBranchesPerMethod.set(0)
+
+        val outputDir = Files.createTempDirectory("btm-task-output")
+        task.outputDir.set(project.layout.dir(project.provider { outputDir.toFile() }))
+
+        task.generate()
+        val outputFile = outputDir.resolve("tracing.btm").toFile()
+        val firstRun = outputFile.readText()
+
+        task.generate()
+        val secondRun = outputFile.readText()
+
+        assertEquals(firstRun, secondRun, "Parallel generation should be deterministic")
+
+        val alphaRuleIndex = firstRun.indexOf("RULE enter@com.example.Alpha.slow")
+        val betaRuleIndex = firstRun.indexOf("RULE enter@com.example.Beta.fast")
+        assertTrue(alphaRuleIndex >= 0 && betaRuleIndex >= 0, "Expected rules for both classes to be present")
+        assertTrue(alphaRuleIndex < betaRuleIndex, "Alpha rules should precede Beta rules in deterministic output\n$firstRun")
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure Java rule generation uses an ordered traversal when parallelism is enabled so rules append deterministically
- add a unit test that forces parallel Java scanning and asserts consistent ordering across runs
- include gradleTestKit in the test classpath so the task can be instantiated in unit tests

## Testing
- gradle test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68d6f13443908326812dc2ddd53381c4