### PR TITLE
Add safe mode decorator and helper hook

### DIFF
--- a/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/SafeModeDecorator.java
+++ b/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/SafeModeDecorator.java
@@ -1,0 +1,32 @@
+package de.burger.forensics.plugin.strategy;
+
+import java.util.Objects;
+
+/** Decorates a ConditionStrategy and routes unsafe expressions through a helper hook. */
+public final class SafeModeDecorator implements ConditionStrategy {
+    private final ConditionStrategy delegate;
+    private final boolean safeMode;
+    private final String helperFqcn;
+    private final String ruleId;
+
+    public SafeModeDecorator(ConditionStrategy delegate, boolean safeMode, String helperFqcn, String ruleId) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.safeMode = safeMode;
+        this.helperFqcn = Objects.requireNonNull(helperFqcn, "helperFqcn");
+        this.ruleId = Objects.requireNonNull(ruleId, "ruleId");
+    }
+
+    @Override
+    public String toBytemanIf() {
+        if (!safeMode || isInlineSafe(delegate)) {
+            return delegate.toBytemanIf();
+        }
+        return helperFqcn + ".ifMatch(\"" + ruleId + "\")";
+    }
+
+    private static boolean isInlineSafe(ConditionStrategy strategy) {
+        return strategy instanceof EqualsLiteralStrategy
+            || strategy instanceof InstanceOfStrategy
+            || strategy instanceof BooleanCompositeStrategy;
+    }
+}

--- a/forensics-btmgen/src/main/java/de/burger/forensics/plugin/util/RuleIdUtil.java
+++ b/forensics-btmgen/src/main/java/de/burger/forensics/plugin/util/RuleIdUtil.java
@@ -1,0 +1,14 @@
+package de.burger.forensics.plugin.util;
+
+import java.util.Objects;
+
+/** Utility that generates stable identifiers for helper-based rule evaluation. */
+public final class RuleIdUtil {
+    private RuleIdUtil() {
+    }
+
+    public static String stableRuleId(String className, String methodName, int lineNumber, String expression) {
+        int hash = Objects.hash(className, methodName, lineNumber, expression);
+        return Integer.toHexString(hash);
+    }
+}

--- a/forensics-btmgen/src/main/java/org/example/trace/SafeEval.java
+++ b/forensics-btmgen/src/main/java/org/example/trace/SafeEval.java
@@ -1,0 +1,12 @@
+package org.example.trace;
+
+/** Placeholder helper used when safe mode delegates evaluation to a helper hook. */
+public final class SafeEval {
+    private SafeEval() {
+    }
+
+    public static boolean ifMatch(String ruleId) {
+        // Step 2 stub: real evaluation will arrive in a later step.
+        return true;
+    }
+}

--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenExtension.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenExtension.kt
@@ -26,6 +26,7 @@ abstract class BtmGenExtension @Inject constructor(
     val shardOutput: Property<Int> = objects.property(Int::class.java)
     val gzipOutput: Property<Boolean> = objects.property(Boolean::class.java)
     val minBranchesPerMethod: Property<Int> = objects.property(Int::class.java)
+    val safeMode: Property<Boolean> = objects.property(Boolean::class.java)
     val outputDir: DirectoryProperty = objects.directoryProperty()
     /**
      * Maximum number of characters allowed when embedding source snippets or values into
@@ -56,5 +57,6 @@ abstract class BtmGenExtension @Inject constructor(
         minBranchesPerMethod.convention(0)
         outputDir.convention(layout.buildDirectory.dir("forensics"))
         maxStringLength.convention(0)
+        safeMode.convention(false)
     }
 }

--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenPlugin.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenPlugin.kt
@@ -32,6 +32,7 @@ class BtmGenPlugin : Plugin<Project> {
             task.shardOutput.set(extension.shardOutput)
             task.gzipOutput.set(extension.gzipOutput)
             task.minBranchesPerMethod.set(extension.minBranchesPerMethod)
+            task.safeMode.set(extension.safeMode)
         }
     }
 }

--- a/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/FactoryDecoratorInteropTest.java
+++ b/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/FactoryDecoratorInteropTest.java
@@ -1,0 +1,24 @@
+package de.burger.forensics.plugin.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FactoryDecoratorInteropTest {
+    private static final String HELPER = "org.example.trace.SafeEval";
+    private final StrategyFactory factory = new DefaultStrategyFactory();
+
+    @Test
+    void rawUnsafeExpressionUsesHelperWhenSafeModeEnabled() {
+        ConditionStrategy base = factory.from("x != null && x.equals(\"OK\")");
+        ConditionStrategy decorated = new SafeModeDecorator(base, true, HELPER, "id1");
+        assertThat(decorated.toBytemanIf()).isEqualTo(HELPER + ".ifMatch(\"id1\")");
+    }
+
+    @Test
+    void equalsLiteralRemainsInlineWhenSafeModeEnabled() {
+        ConditionStrategy base = factory.from("user.status == \"OK\"");
+        ConditionStrategy decorated = new SafeModeDecorator(base, true, HELPER, "id2");
+        assertThat(decorated.toBytemanIf()).isEqualTo("user.status == \"OK\"");
+    }
+}

--- a/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/SafeModeDecoratorTest.java
+++ b/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/SafeModeDecoratorTest.java
@@ -1,0 +1,51 @@
+package de.burger.forensics.plugin.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SafeModeDecoratorTest {
+    private static final String HELPER = "org.example.trace.SafeEval";
+
+    @Test
+    void delegatesWhenSafeModeDisabled() {
+        ConditionStrategy delegate = new OriginalExpressionStrategy("x != null && x.equals(\"OK\")");
+        ConditionStrategy decorated = new SafeModeDecorator(delegate, false, HELPER, "abc");
+        assertThat(decorated.toBytemanIf()).isEqualTo(delegate.toBytemanIf());
+    }
+
+    @Test
+    void keepsEqualsLiteralInlineWhenSafeModeEnabled() {
+        ConditionStrategy delegate = new EqualsLiteralStrategy("user.status", "\"OK\"");
+        ConditionStrategy decorated = new SafeModeDecorator(delegate, true, HELPER, "rid1");
+        assertThat(decorated.toBytemanIf()).isEqualTo("user.status == \"OK\"");
+    }
+
+    @Test
+    void keepsInstanceOfInlineWhenSafeModeEnabled() {
+        ConditionStrategy delegate = new InstanceOfStrategy("obj", "MyType");
+        ConditionStrategy decorated = new SafeModeDecorator(delegate, true, HELPER, "rid2");
+        assertThat(decorated.toBytemanIf()).isEqualTo("obj instanceof MyType");
+    }
+
+    @Test
+    void keepsBooleanCompositeInlineWhenSafeModeEnabled() {
+        ConditionStrategy left = new EqualsLiteralStrategy("user.status", "\"OK\"");
+        ConditionStrategy right = new EqualsLiteralStrategy("user.role", "\"ADMIN\"");
+        ConditionStrategy composite = new BooleanCompositeStrategy(
+            BooleanCompositeStrategy.Op.AND,
+            List.of(left, right)
+        );
+        ConditionStrategy decorated = new SafeModeDecorator(composite, true, HELPER, "rid3");
+        assertThat(decorated.toBytemanIf())
+            .isEqualTo("(user.status == \"OK\") AND (user.role == \"ADMIN\")");
+    }
+
+    @Test
+    void routesUnsafeExpressionThroughHelperWhenSafeModeEnabled() {
+        ConditionStrategy delegate = new OriginalExpressionStrategy("x != null && x.equals(\"OK\")");
+        ConditionStrategy decorated = new SafeModeDecorator(delegate, true, HELPER, "deadbeef");
+        assertThat(decorated.toBytemanIf()).isEqualTo(HELPER + ".ifMatch(\"deadbeef\")");
+    }
+}

--- a/forensics-btmgen/src/test/java/de/burger/forensics/plugin/util/RuleIdUtilTest.java
+++ b/forensics-btmgen/src/test/java/de/burger/forensics/plugin/util/RuleIdUtilTest.java
@@ -1,0 +1,21 @@
+package de.burger.forensics.plugin.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RuleIdUtilTest {
+    @Test
+    void producesStableIdForSameInput() {
+        String first = RuleIdUtil.stableRuleId("C", "m", 42, "expr");
+        String second = RuleIdUtil.stableRuleId("C", "m", 42, "expr");
+        assertThat(first).isEqualTo(second);
+    }
+
+    @Test
+    void producesDifferentIdsForDifferentInput() {
+        String first = RuleIdUtil.stableRuleId("C", "m", 42, "expr");
+        String second = RuleIdUtil.stableRuleId("C", "m", 43, "expr");
+        assertThat(first).isNotEqualTo(second);
+    }
+}


### PR DESCRIPTION
## Summary
- add a safeMode toggle to the Gradle extension/task configuration
- introduce a SafeModeDecorator that routes unsafe strategies through the SafeEval helper with stable rule ids
- provide a SafeEval stub and unit tests covering decorator behaviour and rule id stability

## Testing
- gradle --console plain --no-daemon test


------
https://chatgpt.com/codex/tasks/task_e_68d6fb8c3cd08326952acbce3fb4df78