### PR TITLE
Implement SafeEval helper evaluation and helper-based rendering

### DIFF
--- a/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/BooleanCompositeStrategy.java
+++ b/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/BooleanCompositeStrategy.java
@@ -21,4 +21,18 @@ public final class BooleanCompositeStrategy implements ConditionStrategy {
             .reduce((a, b) -> "(" + a + ") " + op.name() + " (" + b + ")")
             .orElse("true");
     }
+
+    @Override
+    public String toHelperIf(String helperFqcn, String ruleId) {
+        if (children.isEmpty()) {
+            return "true";
+        }
+        String acc = children.get(0).toHelperIf(helperFqcn, ruleId);
+        for (int i = 1; i < children.size(); i++) {
+            String rhs = children.get(i).toHelperIf(helperFqcn, ruleId);
+            String fun = op == Op.AND ? "and" : "or";
+            acc = helperFqcn + "." + fun + "(" + acc + ", " + rhs + ")";
+        }
+        return acc;
+    }
 }

--- a/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/ConditionStrategy.java
+++ b/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/ConditionStrategy.java
@@ -9,4 +9,9 @@ public interface ConditionStrategy {
     default String kind() {
         return getClass().getSimpleName();
     }
+
+    /** Render the IF expression using helper calls to {@code helperFqcn}. */
+    default String toHelperIf(String helperFqcn, String ruleId) {
+        return helperFqcn + ".ifMatch(\"" + ruleId + "\")";
+    }
 }

--- a/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/EqualsLiteralStrategy.java
+++ b/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/EqualsLiteralStrategy.java
@@ -14,4 +14,9 @@ public final class EqualsLiteralStrategy implements ConditionStrategy {
     public String toBytemanIf() {
         return leftExpr + " == " + literal;
     }
+
+    @Override
+    public String toHelperIf(String helperFqcn, String ruleId) {
+        return helperFqcn + ".ifEq(" + leftExpr + ", " + literal + ")";
+    }
 }

--- a/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/InstanceOfStrategy.java
+++ b/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/InstanceOfStrategy.java
@@ -14,4 +14,9 @@ public final class InstanceOfStrategy implements ConditionStrategy {
     public String toBytemanIf() {
         return expr + " instanceof " + fqcn;
     }
+
+    @Override
+    public String toHelperIf(String helperFqcn, String ruleId) {
+        return helperFqcn + ".ifInstanceOf(" + expr + ", \"" + fqcn + "\")";
+    }
 }

--- a/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/SafeModeDecorator.java
+++ b/forensics-btmgen/src/main/java/de/burger/forensics/plugin/strategy/SafeModeDecorator.java
@@ -6,22 +6,27 @@ import java.util.Objects;
 public final class SafeModeDecorator implements ConditionStrategy {
     private final ConditionStrategy delegate;
     private final boolean safeMode;
+    private final boolean forceHelperForWhitelist;
     private final String helperFqcn;
     private final String ruleId;
 
-    public SafeModeDecorator(ConditionStrategy delegate, boolean safeMode, String helperFqcn, String ruleId) {
+    public SafeModeDecorator(ConditionStrategy delegate, boolean safeMode, boolean forceHelperForWhitelist, String helperFqcn, String ruleId) {
         this.delegate = Objects.requireNonNull(delegate, "delegate");
         this.safeMode = safeMode;
+        this.forceHelperForWhitelist = forceHelperForWhitelist;
         this.helperFqcn = Objects.requireNonNull(helperFqcn, "helperFqcn");
         this.ruleId = Objects.requireNonNull(ruleId, "ruleId");
     }
 
     @Override
     public String toBytemanIf() {
-        if (!safeMode || isInlineSafe(delegate)) {
+        if (!safeMode) {
             return delegate.toBytemanIf();
         }
-        return helperFqcn + ".ifMatch(\"" + ruleId + "\")";
+        if (isInlineSafe(delegate) && !forceHelperForWhitelist) {
+            return delegate.toBytemanIf();
+        }
+        return delegate.toHelperIf(helperFqcn, ruleId);
     }
 
     private static boolean isInlineSafe(ConditionStrategy strategy) {

--- a/forensics-btmgen/src/main/java/org/example/trace/SafeEval.java
+++ b/forensics-btmgen/src/main/java/org/example/trace/SafeEval.java
@@ -1,12 +1,110 @@
 package org.example.trace;
 
-/** Placeholder helper used when safe mode delegates evaluation to a helper hook. */
+import java.math.BigDecimal;
+
+/**
+ * Side-effect free helper used in Byteman IF expressions.
+ * All methods are pure, null-safe, and do not call application code.
+ */
 public final class SafeEval {
     private SafeEval() {
     }
 
+    /** Null-safe equality: compares primitives, numbers, enums, and strings reliably. */
+    public static boolean ifEq(Object value, Object literal) {
+        if (value == literal) {
+            return true;
+        }
+        if (value == null || literal == null) {
+            return false;
+        }
+        if (value instanceof Enum<?> vEnum && literal instanceof String litStr) {
+            return vEnum.name().contentEquals(litStr);
+        }
+        if (literal instanceof Enum<?> lEnum && value instanceof String valStr) {
+            return lEnum.name().contentEquals(valStr);
+        }
+        if (isNumber(value) && isNumber(literal)) {
+            return toBigDecimal(value).compareTo(toBigDecimal(literal)) == 0;
+        }
+        return value.equals(literal);
+    }
+
+    /** Type check without triggering user code. */
+    public static boolean ifInstanceOf(Object value, String fqcn) {
+        if (value == null || fqcn == null || fqcn.isEmpty()) {
+            return false;
+        }
+        Class<?> current = value.getClass();
+        while (current != null) {
+            if (current.getName().equals(fqcn)) {
+                return true;
+            }
+            if (implementsInterface(current, fqcn)) {
+                return true;
+            }
+            current = current.getSuperclass();
+        }
+        return false;
+    }
+
+    public static boolean and(boolean a, boolean b) {
+        return a && b;
+    }
+
+    public static boolean or(boolean a, boolean b) {
+        return a || b;
+    }
+
+    /** Legacy generic hook: can be kept as trivial true or wired later. */
     public static boolean ifMatch(String ruleId) {
-        // Step 2 stub: real evaluation will arrive in a later step.
         return true;
+    }
+
+    private static boolean isNumber(Object value) {
+        return value instanceof Byte
+            || value instanceof Short
+            || value instanceof Integer
+            || value instanceof Long
+            || value instanceof Float
+            || value instanceof Double
+            || value instanceof BigDecimal;
+    }
+
+    private static BigDecimal toBigDecimal(Object value) {
+        if (value instanceof BigDecimal bigDecimal) {
+            return bigDecimal;
+        }
+        if (value instanceof Byte b) {
+            return BigDecimal.valueOf(b.longValue());
+        }
+        if (value instanceof Short s) {
+            return BigDecimal.valueOf(s.longValue());
+        }
+        if (value instanceof Integer i) {
+            return BigDecimal.valueOf(i.longValue());
+        }
+        if (value instanceof Long l) {
+            return BigDecimal.valueOf(l.longValue());
+        }
+        if (value instanceof Float f) {
+            return new BigDecimal(String.valueOf(f));
+        }
+        if (value instanceof Double d) {
+            return new BigDecimal(String.valueOf(d));
+        }
+        return new BigDecimal(String.valueOf(value));
+    }
+
+    private static boolean implementsInterface(Class<?> type, String fqcn) {
+        for (Class<?> iface : type.getInterfaces()) {
+            if (iface.getName().equals(fqcn)) {
+                return true;
+            }
+            if (implementsInterface(iface, fqcn)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenExtension.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenExtension.kt
@@ -27,6 +27,7 @@ abstract class BtmGenExtension @Inject constructor(
     val gzipOutput: Property<Boolean> = objects.property(Boolean::class.java)
     val minBranchesPerMethod: Property<Int> = objects.property(Int::class.java)
     val safeMode: Property<Boolean> = objects.property(Boolean::class.java)
+    val forceHelperForWhitelist: Property<Boolean> = objects.property(Boolean::class.java)
     val outputDir: DirectoryProperty = objects.directoryProperty()
     /**
      * Maximum number of characters allowed when embedding source snippets or values into
@@ -58,5 +59,6 @@ abstract class BtmGenExtension @Inject constructor(
         outputDir.convention(layout.buildDirectory.dir("forensics"))
         maxStringLength.convention(0)
         safeMode.convention(false)
+        forceHelperForWhitelist.convention(false)
     }
 }

--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenPlugin.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenPlugin.kt
@@ -33,6 +33,7 @@ class BtmGenPlugin : Plugin<Project> {
             task.gzipOutput.set(extension.gzipOutput)
             task.minBranchesPerMethod.set(extension.minBranchesPerMethod)
             task.safeMode.set(extension.safeMode)
+            task.forceHelperForWhitelist.set(extension.forceHelperForWhitelist)
         }
     }
 }

--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/GenerateBtmTask.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/GenerateBtmTask.kt
@@ -88,6 +88,9 @@ abstract class GenerateBtmTask : DefaultTask() {
     @get:Input
     abstract val safeMode: Property<Boolean>
 
+    @get:Input
+    abstract val forceHelperForWhitelist: Property<Boolean>
+
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
 
@@ -618,7 +621,13 @@ abstract class GenerateBtmTask : DefaultTask() {
         rawExpression: String
     ): ConditionStrategy {
         val ruleId = RuleIdUtil.stableRuleId(className, methodName, line, rawExpression)
-        return SafeModeDecorator(base, safeMode.getOrElse(false), SAFE_EVAL_FQCN, ruleId)
+        return SafeModeDecorator(
+            base,
+            safeMode.getOrElse(false),
+            forceHelperForWhitelist.getOrElse(false),
+            SAFE_EVAL_FQCN,
+            ruleId
+        )
     }
 
 

--- a/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/FactoryDecoratorInteropTest.java
+++ b/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/FactoryDecoratorInteropTest.java
@@ -11,14 +11,14 @@ class FactoryDecoratorInteropTest {
     @Test
     void rawUnsafeExpressionUsesHelperWhenSafeModeEnabled() {
         ConditionStrategy base = factory.from("x != null && x.equals(\"OK\")");
-        ConditionStrategy decorated = new SafeModeDecorator(base, true, HELPER, "id1");
+        ConditionStrategy decorated = new SafeModeDecorator(base, true, false, HELPER, "id1");
         assertThat(decorated.toBytemanIf()).isEqualTo(HELPER + ".ifMatch(\"id1\")");
     }
 
     @Test
     void equalsLiteralRemainsInlineWhenSafeModeEnabled() {
         ConditionStrategy base = factory.from("user.status == \"OK\"");
-        ConditionStrategy decorated = new SafeModeDecorator(base, true, HELPER, "id2");
+        ConditionStrategy decorated = new SafeModeDecorator(base, true, false, HELPER, "id2");
         assertThat(decorated.toBytemanIf()).isEqualTo("user.status == \"OK\"");
     }
 }

--- a/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/SafeModeDecoratorInteropTest.java
+++ b/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/SafeModeDecoratorInteropTest.java
@@ -1,0 +1,34 @@
+package de.burger.forensics.plugin.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SafeModeDecoratorInteropTest {
+
+    private static final StrategyFactory FACTORY = new DefaultStrategyFactory();
+    private static final String H = "org.example.trace.SafeEval";
+
+    @Test
+    void safeMode_inline_for_whitelist_by_default() {
+        ConditionStrategy base = FACTORY.from("user.status == \"OK\"");
+        ConditionStrategy decorated = new SafeModeDecorator(base, true, false, H, "id1");
+        assertThat(decorated.toBytemanIf()).isEqualTo("user.status == \"OK\"");
+    }
+
+    @Test
+    void safeMode_force_helper_for_whitelist_when_flag_on() {
+        ConditionStrategy base = FACTORY.from("user.status == \"OK\"");
+        ConditionStrategy decorated = new SafeModeDecorator(base, true, true, H, "id2");
+        assertThat(decorated.toBytemanIf())
+            .isEqualTo("org.example.trace.SafeEval.ifEq(user.status, \"OK\")");
+    }
+
+    @Test
+    void safeMode_unsafe_goes_to_helper() {
+        ConditionStrategy base = FACTORY.from("x != null && x.equals(\"OK\")");
+        ConditionStrategy decorated = new SafeModeDecorator(base, true, false, H, "id3");
+        assertThat(decorated.toBytemanIf())
+            .isEqualTo("org.example.trace.SafeEval.ifMatch(\"id3\")");
+    }
+}

--- a/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/SafeModeDecoratorTest.java
+++ b/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/SafeModeDecoratorTest.java
@@ -11,21 +11,21 @@ class SafeModeDecoratorTest {
     @Test
     void delegatesWhenSafeModeDisabled() {
         ConditionStrategy delegate = new OriginalExpressionStrategy("x != null && x.equals(\"OK\")");
-        ConditionStrategy decorated = new SafeModeDecorator(delegate, false, HELPER, "abc");
+        ConditionStrategy decorated = new SafeModeDecorator(delegate, false, false, HELPER, "abc");
         assertThat(decorated.toBytemanIf()).isEqualTo(delegate.toBytemanIf());
     }
 
     @Test
     void keepsEqualsLiteralInlineWhenSafeModeEnabled() {
         ConditionStrategy delegate = new EqualsLiteralStrategy("user.status", "\"OK\"");
-        ConditionStrategy decorated = new SafeModeDecorator(delegate, true, HELPER, "rid1");
+        ConditionStrategy decorated = new SafeModeDecorator(delegate, true, false, HELPER, "rid1");
         assertThat(decorated.toBytemanIf()).isEqualTo("user.status == \"OK\"");
     }
 
     @Test
     void keepsInstanceOfInlineWhenSafeModeEnabled() {
         ConditionStrategy delegate = new InstanceOfStrategy("obj", "MyType");
-        ConditionStrategy decorated = new SafeModeDecorator(delegate, true, HELPER, "rid2");
+        ConditionStrategy decorated = new SafeModeDecorator(delegate, true, false, HELPER, "rid2");
         assertThat(decorated.toBytemanIf()).isEqualTo("obj instanceof MyType");
     }
 
@@ -37,7 +37,7 @@ class SafeModeDecoratorTest {
             BooleanCompositeStrategy.Op.AND,
             List.of(left, right)
         );
-        ConditionStrategy decorated = new SafeModeDecorator(composite, true, HELPER, "rid3");
+        ConditionStrategy decorated = new SafeModeDecorator(composite, true, false, HELPER, "rid3");
         assertThat(decorated.toBytemanIf())
             .isEqualTo("(user.status == \"OK\") AND (user.role == \"ADMIN\")");
     }
@@ -45,7 +45,7 @@ class SafeModeDecoratorTest {
     @Test
     void routesUnsafeExpressionThroughHelperWhenSafeModeEnabled() {
         ConditionStrategy delegate = new OriginalExpressionStrategy("x != null && x.equals(\"OK\")");
-        ConditionStrategy decorated = new SafeModeDecorator(delegate, true, HELPER, "deadbeef");
+        ConditionStrategy decorated = new SafeModeDecorator(delegate, true, false, HELPER, "deadbeef");
         assertThat(decorated.toBytemanIf()).isEqualTo(HELPER + ".ifMatch(\"deadbeef\")");
     }
 }

--- a/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/StrategyHelperRenderTest.java
+++ b/forensics-btmgen/src/test/java/de/burger/forensics/plugin/strategy/StrategyHelperRenderTest.java
@@ -1,0 +1,46 @@
+package de.burger.forensics.plugin.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StrategyHelperRenderTest {
+
+    private static final String H = "org.example.trace.SafeEval";
+
+    @Test
+    void equals_literal_renders_ifEq() {
+        ConditionStrategy strategy = new EqualsLiteralStrategy("user.status", "\"OK\"");
+        assertThat(strategy.toHelperIf(H, "rid"))
+            .isEqualTo("org.example.trace.SafeEval.ifEq(user.status, \"OK\")");
+    }
+
+    @Test
+    void instanceof_renders_ifInstanceOf() {
+        ConditionStrategy strategy = new InstanceOfStrategy("obj", "com.acme.Foo");
+        assertThat(strategy.toHelperIf(H, "rid"))
+            .isEqualTo("org.example.trace.SafeEval.ifInstanceOf(obj, \"com.acme.Foo\")");
+    }
+
+    @Test
+    void composite_builds_nested_and_or() {
+        ConditionStrategy a = new EqualsLiteralStrategy("a", "1");
+        ConditionStrategy b = new InstanceOfStrategy("b", "X");
+        ConditionStrategy c = new EqualsLiteralStrategy("c", "'Y'");
+        ConditionStrategy andStrategy =
+            new BooleanCompositeStrategy(BooleanCompositeStrategy.Op.AND, List.of(a, b));
+        ConditionStrategy orStrategy =
+            new BooleanCompositeStrategy(BooleanCompositeStrategy.Op.OR, List.of(andStrategy, c));
+        String expected = H + ".or(" + H + ".and(" + H + ".ifEq(a, 1), " + H
+            + ".ifInstanceOf(b, \"X\")), " + H + ".ifEq(c, 'Y'))";
+        assertThat(orStrategy.toHelperIf(H, "rid")).isEqualTo(expected);
+    }
+
+    @Test
+    void original_expression_falls_back_to_ifMatch() {
+        ConditionStrategy strategy = new OriginalExpressionStrategy("x != null && check(x)");
+        assertThat(strategy.toHelperIf(H, "abc"))
+            .isEqualTo("org.example.trace.SafeEval.ifMatch(\"abc\")");
+    }
+}

--- a/forensics-btmgen/src/test/java/org/example/trace/SafeEvalTest.java
+++ b/forensics-btmgen/src/test/java/org/example/trace/SafeEvalTest.java
@@ -1,0 +1,54 @@
+package org.example.trace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class SafeEvalTest {
+
+    @Test
+    void eq_nulls_trueOnlyWhenBothNull() {
+        assertThat(SafeEval.ifEq(null, null)).isTrue();
+        assertThat(SafeEval.ifEq(null, "x")).isFalse();
+        assertThat(SafeEval.ifEq("x", null)).isFalse();
+    }
+
+    @Test
+    void eq_numbers_robust() {
+        assertThat(SafeEval.ifEq(1, 1L)).isTrue();
+        assertThat(SafeEval.ifEq(1.0, new BigDecimal("1.0"))).isTrue();
+        assertThat(SafeEval.ifEq(1.0, 1.0001)).isFalse();
+    }
+
+    @Test
+    void eq_enums_byName() {
+        enum C { OK, NOK }
+        assertThat(SafeEval.ifEq(C.OK, "OK")).isTrue();
+        assertThat(SafeEval.ifEq(C.NOK, "OK")).isFalse();
+        assertThat(SafeEval.ifEq("OK", C.OK)).isTrue();
+    }
+
+    @Test
+    void eq_strings_equals() {
+        assertThat(SafeEval.ifEq("OK", "OK")).isTrue();
+        assertThat(SafeEval.ifEq("OK", "ok")).isFalse();
+    }
+
+    @Test
+    void instanceOf_checksHierarchyAndInterfaces() {
+        class A implements java.io.Serializable {}
+        A a = new A();
+        assertThat(SafeEval.ifInstanceOf(a, "java.io.Serializable")).isTrue();
+        assertThat(SafeEval.ifInstanceOf(a, "java.lang.Number")).isFalse();
+        assertThat(SafeEval.ifInstanceOf(null, "java.lang.Object")).isFalse();
+    }
+
+    @Test
+    void combinators_shortCircuitSemantics() {
+        assertThat(SafeEval.and(true, true)).isTrue();
+        assertThat(SafeEval.and(true, false)).isFalse();
+        assertThat(SafeEval.or(false, true)).isTrue();
+        assertThat(SafeEval.or(false, false)).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- implement SafeEval with null-safe equality, type checks, and boolean combinators
- allow condition strategies to render helper expressions and update SafeModeDecorator with optional forcing flag
- expose the new DSL flag through the Gradle extension/task and add JUnit 5 coverage for helper evaluation and rendering

## Testing
- gradle clean test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68d6fe1716fc8326bb151e27b27a033b