### PR TITLE
Add SafeEval registry and generator-side predicate registration

### DIFF
--- a/forensics-btmgen/src/main/java/de/burger/forensics/plugin/translate/UnsafeExprTranslator.java
+++ b/forensics-btmgen/src/main/java/de/burger/forensics/plugin/translate/UnsafeExprTranslator.java
@@ -1,0 +1,302 @@
+package de.burger.forensics.plugin.translate;
+
+/**
+ * Translates a restricted subset of raw expressions into SafeEval helper calls.
+ * Only supports: '==', '!=', 'instanceof', '&&', '||' with simple identifiers or literals.
+ * Falls back to "true" for anything else, ensuring the generated evaluator stays safe.
+ */
+public final class UnsafeExprTranslator {
+    private static final String HELPER = "org.example.trace.SafeEval";
+
+    private UnsafeExprTranslator() {
+    }
+
+    public static String toHelperExpr(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return "true";
+        }
+        Parser parser = new Parser(raw);
+        String result = parser.parseExpression();
+        if (!parser.atEnd() || parser.failed()) {
+            return "true";
+        }
+        if (result == null || result.isBlank()) {
+            return "true";
+        }
+        if (!result.contains(HELPER + ".")) {
+            return "true";
+        }
+        return result;
+    }
+
+    private static final class Parser {
+        private final String input;
+        private int pos;
+        private boolean failed;
+
+        private Parser(String input) {
+            this.input = input;
+            this.pos = 0;
+            this.failed = false;
+        }
+
+        private boolean failed() {
+            return failed;
+        }
+
+        private boolean atEnd() {
+            skipWhitespace();
+            return pos >= input.length();
+        }
+
+        private String parseExpression() {
+            String expr = parseOr();
+            if (failed) {
+                return null;
+            }
+            return expr;
+        }
+
+        private String parseOr() {
+            String left = parseAnd();
+            if (failed) {
+                return null;
+            }
+            while (true) {
+                int checkpoint = pos;
+                if (!match("||")) {
+                    pos = checkpoint;
+                    break;
+                }
+                String right = parseAnd();
+                if (failed || right == null) {
+                    failed = true;
+                    return null;
+                }
+                if (left == null) {
+                    failed = true;
+                    return null;
+                }
+                left = HELPER + ".or(" + left + ", " + right + ")";
+            }
+            return left;
+        }
+
+        private String parseAnd() {
+            String left = parseComparison();
+            if (failed) {
+                return null;
+            }
+            while (true) {
+                int checkpoint = pos;
+                if (!match("&&")) {
+                    pos = checkpoint;
+                    break;
+                }
+                String right = parseComparison();
+                if (failed || right == null) {
+                    failed = true;
+                    return null;
+                }
+                if (left == null) {
+                    failed = true;
+                    return null;
+                }
+                left = HELPER + ".and(" + left + ", " + right + ")";
+            }
+            return left;
+        }
+
+        private String parseComparison() {
+            String left = parsePrimary();
+            if (failed) {
+                return null;
+            }
+            skipWhitespace();
+            if (match("instanceof")) {
+                skipWhitespace();
+                String type = parseType();
+                if (failed || type == null) {
+                    failed = true;
+                    return null;
+                }
+                return HELPER + ".ifInstanceOf(" + left + ", \"" + type + "\")";
+            }
+            if (match("==")) {
+                skipWhitespace();
+                String right = parseValue();
+                if (failed || right == null) {
+                    failed = true;
+                    return null;
+                }
+                return HELPER + ".ifEq(" + left + ", " + right + ")";
+            }
+            if (match("!=")) {
+                skipWhitespace();
+                String right = parseValue();
+                if (failed || right == null) {
+                    failed = true;
+                    return null;
+                }
+                return "!" + HELPER + ".ifEq(" + left + ", " + right + ")";
+            }
+            return left;
+        }
+
+        private String parsePrimary() {
+            skipWhitespace();
+            if (peek() == '(') {
+                pos++;
+                String inner = parseOr();
+                if (failed) {
+                    return null;
+                }
+                skipWhitespace();
+                if (peek() != ')') {
+                    failed = true;
+                    return null;
+                }
+                pos++;
+                return inner;
+            }
+            return parseValue();
+        }
+
+        private String parseValue() {
+            skipWhitespace();
+            if (pos >= input.length()) {
+                failed = true;
+                return null;
+            }
+            char c = input.charAt(pos);
+            if (c == '"' || c == '\'') {
+                return parseQuotedLiteral();
+            }
+            if (c == '-' || Character.isDigit(c)) {
+                return parseNumber();
+            }
+            if (Character.isLetter(c) || c == '_' || c == '$') {
+                return parseIdentifier();
+            }
+            failed = true;
+            return null;
+        }
+
+        private String parseQuotedLiteral() {
+            char quote = input.charAt(pos);
+            int start = pos;
+            pos++;
+            boolean escaped = false;
+            while (pos < input.length()) {
+                char ch = input.charAt(pos);
+                if (ch == quote && !escaped) {
+                    pos++;
+                    return input.substring(start, pos);
+                }
+                if (ch == '\\' && !escaped) {
+                    escaped = true;
+                } else {
+                    escaped = false;
+                }
+                pos++;
+            }
+            failed = true;
+            return null;
+        }
+
+        private String parseNumber() {
+            int start = pos;
+            if (input.charAt(pos) == '-') {
+                pos++;
+            }
+            boolean hasDigits = false;
+            while (pos < input.length()) {
+                char ch = input.charAt(pos);
+                if (Character.isDigit(ch)) {
+                    hasDigits = true;
+                    pos++;
+                } else if (ch == '.') {
+                    pos++;
+                } else {
+                    break;
+                }
+            }
+            if (!hasDigits) {
+                failed = true;
+                return null;
+            }
+            return input.substring(start, pos);
+        }
+
+        private String parseIdentifier() {
+            int start = pos;
+            pos++;
+            while (pos < input.length()) {
+                char ch = input.charAt(pos);
+                if (Character.isLetterOrDigit(ch) || ch == '_' || ch == '$' || ch == '.') {
+                    pos++;
+                } else {
+                    break;
+                }
+            }
+            String ident = input.substring(start, pos).trim();
+            int lookahead = pos;
+            while (lookahead < input.length() && Character.isWhitespace(input.charAt(lookahead))) {
+                lookahead++;
+            }
+            if (lookahead < input.length()) {
+                char next = input.charAt(lookahead);
+                if (next == '(' || next == '[') {
+                    failed = true;
+                    return null;
+                }
+            }
+            return ident;
+        }
+
+        private String parseType() {
+            int start = pos;
+            if (start >= input.length()) {
+                failed = true;
+                return null;
+            }
+            char first = input.charAt(pos);
+            if (!(Character.isLetter(first) || first == '_' || first == '$')) {
+                failed = true;
+                return null;
+            }
+            pos++;
+            while (pos < input.length()) {
+                char ch = input.charAt(pos);
+                if (Character.isLetterOrDigit(ch) || ch == '_' || ch == '$' || ch == '.') {
+                    pos++;
+                } else {
+                    break;
+                }
+            }
+            return input.substring(start, pos).trim();
+        }
+
+        private void skipWhitespace() {
+            while (pos < input.length() && Character.isWhitespace(input.charAt(pos))) {
+                pos++;
+            }
+        }
+
+        private boolean match(String token) {
+            skipWhitespace();
+            if (input.startsWith(token, pos)) {
+                pos += token.length();
+                return true;
+            }
+            return false;
+        }
+
+        private char peek() {
+            if (pos >= input.length()) {
+                return '\0';
+            }
+            return input.charAt(pos);
+        }
+    }
+}

--- a/forensics-btmgen/src/test/java/de/burger/forensics/plugin/translate/UnsafeExprTranslatorTest.java
+++ b/forensics-btmgen/src/test/java/de/burger/forensics/plugin/translate/UnsafeExprTranslatorTest.java
@@ -1,0 +1,51 @@
+package de.burger.forensics.plugin.translate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UnsafeExprTranslatorTest {
+
+    private static final String H = "org.example.trace.SafeEval";
+
+    @Test
+    void equalsToHelper() {
+        String helper = UnsafeExprTranslator.toHelperExpr("user.status == \"OK\"");
+        assertThat(helper).isEqualTo(H + ".ifEq(user.status, \"OK\")");
+    }
+
+    @Test
+    void notEqualsNegatesHelper() {
+        String helper = UnsafeExprTranslator.toHelperExpr("code != 200");
+        assertThat(helper).isEqualTo("!" + H + ".ifEq(code, 200)");
+    }
+
+    @Test
+    void instanceofBecomesHelperCall() {
+        String helper = UnsafeExprTranslator.toHelperExpr("obj instanceof com.acme.Foo");
+        assertThat(helper).isEqualTo(H + ".ifInstanceOf(obj, \"com.acme.Foo\")");
+    }
+
+    @Test
+    void booleanCompositionUsesAndOr() {
+        String helper = UnsafeExprTranslator.toHelperExpr("(a == 1) && (b != 2) || (c instanceof X)");
+        assertThat(helper)
+            .contains(H + ".and(")
+            .contains(H + ".or(")
+            .contains(H + ".ifEq(a, 1)")
+            .contains("!" + H + ".ifEq(b, 2)")
+            .contains(H + ".ifInstanceOf(c, \"X\")");
+    }
+
+    @Test
+    void unsupportedExpressionFallsBackToTrue() {
+        String helper = UnsafeExprTranslator.toHelperExpr("x != null && x.equals(\"OK\")");
+        assertThat(helper).isEqualTo("true");
+    }
+
+    @Test
+    void standaloneUnsafeIdentifierFallsBackToTrue() {
+        String helper = UnsafeExprTranslator.toHelperExpr("flag");
+        assertThat(helper).isEqualTo("true");
+    }
+}

--- a/forensics-btmgen/src/test/java/org/example/trace/SafeEvalRegistryTest.java
+++ b/forensics-btmgen/src/test/java/org/example/trace/SafeEvalRegistryTest.java
@@ -1,0 +1,35 @@
+package org.example.trace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class SafeEvalRegistryTest {
+
+    @AfterEach
+    void resetRegistry() {
+        SafeEval._clearForTests();
+    }
+
+    @Test
+    void returnsTrueWhenNoEvaluatorInstalled() {
+        assertThat(SafeEval.ifMatch("missing")).isTrue();
+    }
+
+    @Test
+    void registersAndEvaluatesPredicates() {
+        SafeEval.register("RID", () -> true);
+        assertThat(SafeEval.ifMatch("RID")).isTrue();
+        SafeEval.register("RID", () -> false);
+        assertThat(SafeEval.ifMatch("RID")).isFalse();
+    }
+
+    @Test
+    void evaluatorExceptionsAreFailOpen() {
+        SafeEval.register("RID", () -> {
+            throw new IllegalStateException("boom");
+        });
+        assertThat(SafeEval.ifMatch("RID")).isTrue();
+    }
+}

--- a/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/SafeModeRegistrationTest.kt
+++ b/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/SafeModeRegistrationTest.kt
@@ -1,0 +1,96 @@
+package de.burger.forensics.plugin
+
+import java.io.File
+import java.nio.file.Files
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+
+class SafeModeRegistrationTest {
+
+    @Test
+    fun unsafeExpressionRegistersEvaluatorWithTranslation() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("generateUnsafe", GenerateBtmTask::class.java).get()
+        val sourceDir = Files.createTempDirectory("btmgen-unsafe-src").toFile()
+        File(sourceDir, "Demo.kt").writeText(
+            """
+            package com.example
+
+            class Demo {
+                fun sample(value: String?) {
+                    if (value != null) {
+                        println(value)
+                    }
+                }
+            }
+            """.trimIndent()
+        )
+        configureTask(task, sourceDir)
+
+        val outputDir = Files.createTempDirectory("btm-output-unsafe")
+        task.outputDir.set(project.layout.dir(project.provider { outputDir.toFile() }))
+
+        task.generate()
+
+        val content = outputDir.resolve("tracing.btm").toFile().readText()
+        val match = Regex("""IF \(org\.example\.trace\.SafeEval\.ifMatch\("([^"]+)"\)\)""").find(content)
+        assertThat(match).isNotNull
+        val ruleId = match!!.groupValues[1]
+        assertThat(content)
+            .contains("DO org.example.trace.SafeEval.register(\"$ruleId\", new org.example.trace.SafeEval.Evaluator() {")
+            .contains("return !org.example.trace.SafeEval.ifEq(value, null);")
+    }
+
+    @Test
+    fun unsupportedExpressionFallsBackToTrueInEvaluatorBody() {
+        val project = ProjectBuilder.builder().build()
+        val task = project.tasks.register("generateFallback", GenerateBtmTask::class.java).get()
+        val sourceDir = Files.createTempDirectory("btmgen-fallback-src").toFile()
+        File(sourceDir, "Demo.kt").writeText(
+            """
+            package com.example
+
+            class Demo {
+                fun sample(value: String?) {
+                    if (value != null && value.equals(\"OK\")) {
+                        println(value)
+                    }
+                }
+            }
+            """.trimIndent()
+        )
+        configureTask(task, sourceDir)
+
+        val outputDir = Files.createTempDirectory("btm-output-fallback")
+        task.outputDir.set(project.layout.dir(project.provider { outputDir.toFile() }))
+
+        task.generate()
+
+        val content = outputDir.resolve("tracing.btm").toFile().readText()
+        val match = Regex("""DO org\.example\.trace\.SafeEval\.register\("([^"]+)", new org\.example\.trace\.SafeEval\.Evaluator\(\) \{""")
+            .find(content)
+        assertThat(match).isNotNull
+        assertThat(content).contains("return true;")
+    }
+
+    private fun configureTask(task: GenerateBtmTask, sourceDir: File) {
+        task.srcDirs.set(listOf(sourceDir.absolutePath))
+        task.packagePrefix.set("com.example")
+        task.helperFqn.set("org.example.trace.SafeEval")
+        task.entryExit.set(false)
+        task.trackedVars.set(emptyList())
+        task.includeJava.set(false)
+        task.includeTimestamp.set(false)
+        task.maxStringLength.set(200)
+        task.pkgPrefixes.set(emptyList())
+        task.includePatterns.set(emptyList())
+        task.excludePatterns.set(emptyList())
+        task.parallelism.set(1)
+        task.shardOutput.set(1)
+        task.gzipOutput.set(false)
+        task.minBranchesPerMethod.set(0)
+        task.safeMode.set(true)
+        task.forceHelperForWhitelist.set(false)
+    }
+}


### PR DESCRIPTION
## Summary
- implement a concurrent helper registry in SafeEval with register/ifMatch fail-open semantics
- emit SafeEval.register evaluators for unsafe conditions via a new UnsafeExprTranslator helper
- cover the registry, translator, and generator integration with new unit and integration tests

## Testing
- gradle test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d700ae1cc88326b4ddbf07dddbe86a