### PR TITLE
Harden Java scanning with prefiltering and caches

### DIFF
--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenExtension.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenExtension.kt
@@ -28,6 +28,7 @@ abstract class BtmGenExtension @Inject constructor(
     val minBranchesPerMethod: Property<Int> = objects.property(Int::class.java)
     val safeMode: Property<Boolean> = objects.property(Boolean::class.java)
     val forceHelperForWhitelist: Property<Boolean> = objects.property(Boolean::class.java)
+    val maxFileBytes: Property<Long> = objects.property(Long::class.java)
     val outputDir: DirectoryProperty = objects.directoryProperty()
     /**
      * Maximum number of characters allowed when embedding source snippets or values into
@@ -60,5 +61,6 @@ abstract class BtmGenExtension @Inject constructor(
         maxStringLength.convention(0)
         safeMode.convention(false)
         forceHelperForWhitelist.convention(false)
+        maxFileBytes.convention(2_000_000L)
     }
 }

--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenPlugin.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/BtmGenPlugin.kt
@@ -34,6 +34,7 @@ class BtmGenPlugin : Plugin<Project> {
             task.minBranchesPerMethod.set(extension.minBranchesPerMethod)
             task.safeMode.set(extension.safeMode)
             task.forceHelperForWhitelist.set(extension.forceHelperForWhitelist)
+            task.maxFileBytes.set(extension.maxFileBytes)
         }
     }
 }

--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/GlobUtils.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/GlobUtils.kt
@@ -1,0 +1,35 @@
+package de.burger.forensics.plugin
+
+import java.util.concurrent.ConcurrentHashMap
+
+private val globCache = ConcurrentHashMap<String, Regex>()
+
+fun globToRegex(glob: String): String {
+    val sb = StringBuilder("^")
+    var i = 0
+    while (i < glob.length) {
+        when (val c = glob[i]) {
+            '*' -> {
+                if (i + 1 < glob.length && glob[i + 1] == '*') {
+                    sb.append(".*")
+                    i++
+                } else {
+                    sb.append("[^/]*")
+                }
+            }
+            '?' -> sb.append('.')
+            '.', '(', ')', '+', '|', '^', '$', '@', '%' -> sb.append('\\').append(c)
+            '{' -> sb.append('(')
+            '}' -> sb.append(')')
+            ',' -> sb.append('|')
+            '[' -> sb.append('[')
+            ']' -> sb.append(']')
+            else -> sb.append(c)
+        }
+        i++
+    }
+    sb.append('$')
+    return sb.toString()
+}
+
+fun globToRegexCached(glob: String): Regex = globCache.computeIfAbsent(glob) { Regex(globToRegex(it)) }

--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/engine/JavaPrefilter.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/engine/JavaPrefilter.kt
@@ -1,0 +1,40 @@
+package de.burger.forensics.plugin.engine
+
+import kotlin.text.RegexOption
+
+private val blockCommentRegex = Regex("/\\*.*?\\*/", setOf(RegexOption.DOT_MATCHES_ALL))
+private val lineCommentRegex = Regex("//.*?$", setOf(RegexOption.MULTILINE))
+private val stringLiteralRegex = Regex("\"(?:[^\"\\\\]|\\\\.)*\"")
+private val charLiteralRegex = Regex("'(?:[^'\\\\]|\\\\.)*'")
+
+fun prefilterJava(source: String): String {
+    val withoutBlock = blockCommentRegex.replace(source) { match ->
+        blankWithNewlines(match.value)
+    }
+    val withoutLine = lineCommentRegex.replace(withoutBlock) { match ->
+        blankWithNewlines(match.value)
+    }
+    val withoutStrings = stringLiteralRegex.replace(withoutLine) { match ->
+        replaceLiteralPreservingLength(match.value, '"')
+    }
+    return charLiteralRegex.replace(withoutStrings) { match ->
+        replaceLiteralPreservingLength(match.value, '\'')
+    }
+}
+
+private fun blankWithNewlines(segment: String): String = buildString(segment.length) {
+    segment.forEach { ch ->
+        append(if (ch == '\n') '\n' else ' ')
+    }
+}
+
+private fun replaceLiteralPreservingLength(literal: String, delimiter: Char): String {
+    if (literal.length <= 2) {
+        return delimiter.toString() + delimiter
+    }
+    return buildString(literal.length) {
+        append(delimiter)
+        repeat(literal.length - 2) { append(' ') }
+        append(delimiter)
+    }
+}

--- a/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/engine/SourceFileGuards.kt
+++ b/forensics-btmgen/src/main/kotlin/de/burger/forensics/plugin/engine/SourceFileGuards.kt
@@ -1,0 +1,13 @@
+package de.burger.forensics.plugin.engine
+
+import java.io.File
+
+fun shouldSkipLargeFile(file: File, maxBytes: Long, debug: (String) -> Unit): Boolean {
+    if (maxBytes <= 0) return false
+    val length = file.length()
+    if (length > maxBytes) {
+        debug("Skipping large file (${length} bytes > limit $maxBytes): ${file.absolutePath}")
+        return true
+    }
+    return false
+}

--- a/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/GlobRegexCacheTest.kt
+++ b/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/GlobRegexCacheTest.kt
@@ -1,0 +1,22 @@
+package de.burger.forensics.plugin
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GlobRegexCacheTest {
+    @Test
+    fun `returns identical instance for identical glob`() {
+        val first = globToRegexCached("**/*.java")
+        val second = globToRegexCached("**/*.java")
+
+        assertThat(first).isSameAs(second)
+    }
+
+    @Test
+    fun `returns different instances for different globs`() {
+        val javaGlob = globToRegexCached("**/*.java")
+        val kotlinGlob = globToRegexCached("**/*.kt")
+
+        assertThat(javaGlob).isNotSameAs(kotlinGlob)
+    }
+}

--- a/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/engine/FileSizeGuardTest.kt
+++ b/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/engine/FileSizeGuardTest.kt
@@ -1,0 +1,39 @@
+package de.burger.forensics.plugin.engine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class FileSizeGuardTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `skips when file exceeds limit`() {
+        val limit = 1_024L
+        val file = Files.createTempFile(tempDir, "big", ".java").toFile()
+        file.writeBytes(ByteArray((limit + 10).toInt()) { 'A'.code.toByte() })
+
+        val messages = mutableListOf<String>()
+        val skipped = shouldSkipLargeFile(file, limit) { messages += it }
+
+        assertThat(skipped).isTrue()
+        assertThat(messages).isNotEmpty()
+        assertThat(messages.first()).contains("Skipping large file")
+    }
+
+    @Test
+    fun `processes when file size is within limit`() {
+        val limit = 1_024L
+        val file = Files.createTempFile(tempDir, "small", ".java").toFile()
+        file.writeBytes(ByteArray(limit.toInt()) { 'B'.code.toByte() })
+
+        val messages = mutableListOf<String>()
+        val skipped = shouldSkipLargeFile(file, limit) { messages += it }
+
+        assertThat(skipped).isFalse()
+        assertThat(messages).isEmpty()
+    }
+}

--- a/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/engine/JavaPrefilterTest.kt
+++ b/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/engine/JavaPrefilterTest.kt
@@ -1,0 +1,31 @@
+package de.burger.forensics.plugin.engine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class JavaPrefilterTest {
+    @Test
+    fun `removes noise but preserves structure`() {
+        val src = """
+            package demo;
+            // line comment with if (false) { fail(); }
+            class A {
+                String s = "keep \"quotes\" // not a comment";
+                /* block
+                   comment */
+                if (x == "OK") { /*inline*/ System.out.println(x); } // tail comment
+                char c = 'x';
+            }
+        """.trimIndent()
+
+        val prefiltered = prefilterJava(src)
+
+        assertThat(prefiltered).doesNotContain("line comment")
+        assertThat(prefiltered).doesNotContain("block\n                   comment")
+        assertThat(prefiltered).doesNotContain("keep \"quotes\" // not a comment")
+        assertThat(prefiltered).contains("class A {")
+        assertThat(prefiltered).contains("if (x == \"")
+        assertThat(prefiltered).doesNotContain("'x'")
+        assertThat(prefiltered.count { it == '\n' }).isEqualTo(src.count { it == '\n' })
+    }
+}

--- a/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/engine/ParserSmokeTest.kt
+++ b/forensics-btmgen/src/test/kotlin/de/burger/forensics/plugin/engine/ParserSmokeTest.kt
@@ -1,0 +1,43 @@
+package de.burger.forensics.plugin.engine
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ParserSmokeTest {
+    private val parser = JavaRegexParser()
+
+    @Test
+    fun `detects branches despite comments and strings`() {
+        val source = """
+            package smoke;
+
+            class Sample {
+                void test(String value) {
+                    // if (value.equals("no")) { unreachable(); }
+                    String marker = "switch(value) { case \"x\": }";
+                    if (value.equals("ok")) {
+                        System.out.println(value);
+                    }
+                    switch (value) {
+                        case "x":
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val rules = parser.scan(
+            text = source,
+            helperFqn = "helper.Fqn",
+            packagePrefix = "smoke",
+            includeEntryExit = false,
+            maxStringLength = 200
+        )
+
+        assertThat(rules).anySatisfy { assertThat(it).contains(":if-true").contains("value.equals(\"ok\")") }
+        assertThat(rules).anySatisfy { assertThat(it).contains(":when") }
+        assertThat(rules).anySatisfy { assertThat(it).contains(":case") }
+    }
+}


### PR DESCRIPTION
## Summary
- add a maxFileBytes DSL option and guard Kotlin/Java scanning against oversized sources
- cache compiled glob patterns and implement a comment/string prefilter for the Java regex parser
- adjust the parser to use the sanitized text while emitting original expressions and add focused JUnit 5 coverage

## Testing
- ./gradlew test *(fails: gradle wrapper jar missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d704b281a083268f8682b3ce72ce3b