### PR TITLE
Handle multiline Kotlin conditions in scanner

### DIFF
--- a/forensics-btmgen/src/test/java/de/burger/forensics/plugin/scan/KotlinAstScannerTest.java
+++ b/forensics-btmgen/src/test/java/de/burger/forensics/plugin/scan/KotlinAstScannerTest.java
@@ -36,6 +36,27 @@ public class KotlinAstScannerTest {
                         else -> "other"
                     }
                 }
+
+                fun multiLineIf(x: Int): Int {
+                    if (
+                        x > 0 &&
+                        x < 10
+                    ) {
+                        return x
+                    }
+                    return -1
+                }
+
+                fun multiLineWhen(text: String): String {
+                    return when (
+                        text
+                            .trim()
+                            .lowercase()
+                    ) {
+                        "yes" -> "y"
+                        else -> "n"
+                    }
+                }
             }
             """.stripIndent());
 
@@ -49,6 +70,14 @@ public class KotlinAstScannerTest {
         Assertions.assertThat(events).anySatisfy(e -> {
             Assertions.assertThat(e.kind()).isEqualTo("switch");
             Assertions.assertThat(e.conditionText()).isEqualTo("flag");
+        });
+        Assertions.assertThat(events).anySatisfy(e -> {
+            Assertions.assertThat(e.kind()).isEqualTo("if-true");
+            Assertions.assertThat(e.conditionText()).isEqualTo("x > 0 && x < 10");
+        });
+        Assertions.assertThat(events).anySatisfy(e -> {
+            Assertions.assertThat(e.kind()).isEqualTo("switch");
+            Assertions.assertThat(e.conditionText()).isEqualTo("text.trim().lowercase()");
         });
         Assertions.assertThat(events).anySatisfy(e -> Assertions.assertThat(e.kind()).isEqualTo("when-branch"));
         Assertions.assertThat(events).anySatisfy(e -> {


### PR DESCRIPTION
## Summary
- teach the Kotlin AST scanner to capture parenthesized if/when conditions across multiple lines and keep the original switch selector text
- normalise whitespace when buffering conditions so the resulting events look clean
- extend the KotlinAstScannerTest with multi-line if/when examples to verify the emitted events

## Testing
- `gradle --console=plain test` *(fails: project cannot compile JavaAstScanner.java because StaticJavaParser#getParserConfiguration() is missing in the available dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ff323c708326b86315e5bc9029c0