### PR TITLE
Add comprehensive tests and re-enable AspectJ logging

### DIFF
--- a/forensics-btmgen/forensics-adapters/byteman/src/test/java/de/burger/forensics/adapters/byteman/BytemanRuleRendererTest.java
+++ b/forensics-btmgen/forensics-adapters/byteman/src/test/java/de/burger/forensics/adapters/byteman/BytemanRuleRendererTest.java
@@ -29,4 +29,52 @@ class BytemanRuleRendererTest {
             .contains("CLASS com.example.Demo")
             .contains("IF (value > 0)");
     }
+
+    @Test
+    void rendersIfFalseRuleWithNegatedCondition() {
+        Rule rule = new Rule(
+            new RuleId("xyz"),
+            new SourceLocation("com.example.Demo", "test", 10),
+            "value > 0",
+            false,
+            "helper",
+            RuleType.IF_FALSE
+        );
+
+        String rendered = renderer.render(rule);
+        assertThat(rendered).contains("IF (!(value > 0))");
+    }
+
+    @Test
+    void rendersSwitchAndCaseRules() {
+        SourceLocation location = new SourceLocation("com.example.Demo", "test", 22);
+        Rule switchRule = new Rule(new RuleId("sw"), location, "selector", true, "helper", RuleType.SWITCH);
+        Rule caseRule = new Rule(new RuleId("case"), location, "value\n\"x\"", true, "helper", RuleType.SWITCH_CASE);
+
+        String switchRendered = renderer.render(switchRule);
+        String caseRendered = renderer.render(caseRule);
+
+        assertThat(switchRendered).contains("DO sw(");
+        assertThat(caseRendered).contains("kase(").contains("\\n").contains("\\\"");
+    }
+
+    @Test
+    void rendersReturnAndThrowRules() {
+        SourceLocation location = new SourceLocation("com.example.Demo", "test", 30);
+        Rule returnRule = new Rule(new RuleId("ret"), location, "return 1", true, "helper", RuleType.RETURN);
+        Rule throwRule = new Rule(new RuleId("thr"), location, "new Ex()", true, "helper", RuleType.THROW);
+
+        assertThat(renderer.render(returnRule)).contains("DO ret(");
+        assertThat(renderer.render(throwRule)).contains("DO thr(").contains("new Ex()");
+    }
+
+    @Test
+    void rendersEntryAndExitRules() {
+        SourceLocation location = new SourceLocation("com.example.Demo", "test", 1);
+        Rule entryRule = new Rule(new RuleId("en"), location, "true", true, "helper", RuleType.ENTRY);
+        Rule exitRule = new Rule(new RuleId("ex"), location, "true", true, "helper", RuleType.EXIT);
+
+        assertThat(renderer.render(entryRule)).contains("AT ENTRY").contains("enter(");
+        assertThat(renderer.render(exitRule)).contains("AT EXIT").contains("exit(");
+    }
 }

--- a/forensics-btmgen/forensics-adapters/javaparser/src/test/java/de/burger/forensics/adapters/javaparser/JavaParserScannerTest.java
+++ b/forensics-btmgen/forensics-adapters/javaparser/src/test/java/de/burger/forensics/adapters/javaparser/JavaParserScannerTest.java
@@ -38,4 +38,33 @@ class JavaParserScannerTest {
                 assertThat(event.location().fqcn()).isEqualTo("example.Sample");
             });
     }
+
+    @Test
+    void scansSwitchReturnAndThrowStatements() throws IOException {
+        Path tempDir = Files.createTempDirectory("scanner-test-2");
+        Path source = tempDir.resolve("Advanced.java");
+        Files.writeString(source, """
+            package example;
+            public class Advanced {
+              public int compute(int value) {
+                if (value > 10) {
+                  throw new IllegalArgumentException();
+                } else if (value < 0) {
+                  return -1;
+                }
+                switch (value) {
+                  case 1 -> value = 2;
+                  default -> value = 3;
+                }
+                return value;
+              }
+            }
+            """
+        );
+
+        List<ScanEvent> events = scanner.scan(tempDir).toList();
+
+        assertThat(events).extracting(ScanEvent::kind)
+            .contains(RuleType.IF_TRUE, RuleType.IF_FALSE, RuleType.SWITCH, RuleType.SWITCH_CASE, RuleType.RETURN, RuleType.THROW);
+    }
 }

--- a/forensics-btmgen/forensics-application/src/test/java/de/burger/forensics/application/service/GenerateRulesUseCaseTest.java
+++ b/forensics-btmgen/forensics-application/src/test/java/de/burger/forensics/application/service/GenerateRulesUseCaseTest.java
@@ -2,6 +2,7 @@ package de.burger.forensics.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.burger.forensics.domain.model.Rule;
 import de.burger.forensics.domain.model.RuleType;
 import de.burger.forensics.domain.model.ScanEvent;
 import de.burger.forensics.domain.model.SourceLocation;
@@ -9,52 +10,40 @@ import de.burger.forensics.domain.port.out.ClockPort;
 import de.burger.forensics.domain.port.out.CodeScanPort;
 import de.burger.forensics.domain.port.out.LogPort;
 import de.burger.forensics.domain.port.out.RuleRenderPort;
-import de.burger.forensics.domain.strategy.DefaultStrategyFactory;
+import de.burger.forensics.domain.strategy.StrategyFactory;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class GenerateRulesUseCaseTest {
 
+    private final StubScanner scanner = new StubScanner();
+    private final CollectingRenderer renderer = new CollectingRenderer();
+    private final SequencingClock clock = new SequencingClock();
+    private final RecordingLog log = new RecordingLog();
+    private final StrategyFactory strategies = expression -> () -> expression == null ? "true" : expression;
+
+    private GenerateRulesUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GenerateRulesUseCase(scanner, renderer, clock, log, strategies);
+    }
+
     @Test
-    void generatesRulesUsingPorts() {
-        SourceLocation location = new SourceLocation("com.example.Test", "doWork", 42);
-        ScanEvent event = new ScanEvent(location, "doWork()", RuleType.IF_TRUE, "x > 0", "java");
-
-        CodeScanPort scanner = root -> Stream.of(event);
-        RuleRenderPort renderer = rule -> "RULE " + rule.id().value();
-        ClockPort clock = () -> Instant.parse("2025-01-01T00:00:00Z");
-        AtomicReference<String> info = new AtomicReference<>();
-        LogPort log = new LogPort() {
-            @Override
-            public void info(String message) {
-                info.set(message);
-            }
-
-            @Override
-            public void warn(String message) {
-            }
-
-            @Override
-            public void debug(String message) {
-            }
-        };
-
-        GenerateRulesUseCase useCase = new GenerateRulesUseCase(
-            scanner,
-            renderer,
-            clock,
-            log,
-            new DefaultStrategyFactory()
-        );
+    void addsEntryExitRulesAndWrapsConditionsInSafeMode() {
+        SourceLocation location = new SourceLocation("com.example.Demo", "run", 12);
+        scanner.setEvents(List.of(new ScanEvent(location, "run()", RuleType.IF_TRUE, "flag", "java")));
 
         GenerationRequest request = new GenerationRequest(
-            Path.of("."),
+            Path.of("src"),
             "org.example.trace.SafeEval",
-            false,
+            true,
             true,
             List.of(),
             0,
@@ -62,11 +51,156 @@ class GenerateRulesUseCaseTest {
         );
 
         RuleGenerationResult result = useCase.generate(request);
+
+        assertThat(result.renderedRules()).hasSize(3);
+        assertThat(renderer.rendered())
+            .extracting(Rule::type)
+            .containsExactlyInAnyOrder(RuleType.ENTRY, RuleType.IF_TRUE, RuleType.EXIT);
+        Rule ifRule = renderer.rendered().stream()
+            .filter(rule -> rule.type() == RuleType.IF_TRUE)
+            .findFirst()
+            .orElseThrow();
+        assertThat(ifRule.condition()).contains("SafeEval.eval").contains("flag");
+        assertThat(log.messages()).hasSize(3);
+    }
+
+    @Test
+    void filtersMethodsByPrefixesAndMinimumBranchCount() {
+        SourceLocation include = new SourceLocation("com.target.Demo", "calc", 20);
+        SourceLocation exclude = new SourceLocation("com.other.Other", "skip", 10);
+        scanner.setEvents(List.of(
+            new ScanEvent(include, "calc()", RuleType.IF_TRUE, "flag", "java"),
+            new ScanEvent(include, "calc()", RuleType.IF_FALSE, "flag", "java"),
+            new ScanEvent(exclude, "skip()", RuleType.IF_TRUE, "flag", "java")
+        ));
+
+        GenerationRequest request = new GenerationRequest(
+            Path.of("src"),
+            "helper",
+            false,
+            false,
+            List.of("com.target"),
+            2,
+            List.of()
+        );
+
+        RuleGenerationResult result = useCase.generate(request);
+
+        assertThat(result.renderedRules()).hasSize(2);
+        assertThat(renderer.rendered()).allSatisfy(rule ->
+            assertThat(rule.location().fqcn()).isEqualTo("com.target.Demo")
+        );
+    }
+
+    @Test
+    void mapsAllEventTypesToRules() {
+        SourceLocation location = new SourceLocation("com.example.Full", "everything", 5);
+        scanner.setEvents(List.of(
+            new ScanEvent(location, "everything()", RuleType.SWITCH, "selector", "java"),
+            new ScanEvent(location, "everything()", RuleType.SWITCH_CASE, "case1", "java"),
+            new ScanEvent(location, "everything()", RuleType.RETURN, "return 1", "java"),
+            new ScanEvent(location, "everything()", RuleType.THROW, "new IllegalStateException()", "java"),
+            new ScanEvent(location, "everything()", RuleType.ENTRY, "true", "java"),
+            new ScanEvent(location, "everything()", RuleType.EXIT, "true", "java"),
+            new ScanEvent(location, "everything()", RuleType.IF_TRUE, "value > 0", "java"),
+            new ScanEvent(location, "everything()", RuleType.IF_FALSE, "value > 0", "java"),
+            new ScanEvent(location, "everything()", RuleType.SWITCH_CASE, "case1", "java")
+        ));
+
+        GenerationRequest request = new GenerationRequest(
+            Path.of("src"),
+            "helper",
+            false,
+            false,
+            List.of(),
+            0,
+            List.of()
+        );
+
+        RuleGenerationResult result = useCase.generate(request);
+
         assertThat(result.renderedRules())
-            .hasSize(3);
-        assertThat(result.renderedRules().get(0)).startsWith("RULE ");
-        assertThat(result.renderedRules().get(1)).startsWith("RULE ");
-        assertThat(result.renderedRules().get(2)).startsWith("RULE ");
-        assertThat(info.get()).contains("Starting rule generation");
+            .contains(
+                "SWITCH:selector",
+                "SWITCH_CASE:case1",
+                "RETURN:return 1",
+                "THROW:new IllegalStateException()",
+                "ENTRY:true",
+                "EXIT:true",
+                "IF_TRUE:value > 0",
+                "IF_FALSE:value > 0"
+            );
+        assertThat(renderer.rendered())
+            .extracting(Rule::type)
+            .contains(
+                RuleType.SWITCH,
+                RuleType.SWITCH_CASE,
+                RuleType.RETURN,
+                RuleType.THROW,
+                RuleType.ENTRY,
+                RuleType.EXIT,
+                RuleType.IF_TRUE,
+                RuleType.IF_FALSE
+            );
+    }
+
+    private static final class StubScanner implements CodeScanPort {
+        private List<ScanEvent> events = List.of();
+
+        void setEvents(List<ScanEvent> events) {
+            this.events = events;
+        }
+
+        @Override
+        public Stream<ScanEvent> scan(Path root) {
+            return events.stream();
+        }
+    }
+
+    private static final class CollectingRenderer implements RuleRenderPort {
+        private final List<Rule> rendered = new ArrayList<>();
+
+        @Override
+        public String render(Rule rule) {
+            rendered.add(rule);
+            return rule.type() + ":" + rule.condition();
+        }
+
+        List<Rule> rendered() {
+            return List.copyOf(rendered);
+        }
+    }
+
+    private static final class SequencingClock implements ClockPort {
+        private final AtomicInteger calls = new AtomicInteger();
+        private Instant instant = Instant.parse("2024-01-01T00:00:00Z");
+
+        @Override
+        public Instant now() {
+            return instant.plusSeconds(calls.getAndIncrement());
+        }
+    }
+
+    private static final class RecordingLog implements LogPort {
+        private final List<String> messages = new ArrayList<>();
+
+        @Override
+        public void info(String message) {
+            messages.add(message);
+        }
+
+        @Override
+        public void warn(String message) {
+            messages.add(message);
+        }
+
+        @Override
+        public void debug(String message) {
+            messages.add(message);
+        }
+
+        List<String> messages() {
+            return List.copyOf(messages);
+        }
     }
 }

--- a/forensics-btmgen/forensics-application/src/test/java/de/burger/forensics/application/service/GenerationRequestTest.java
+++ b/forensics-btmgen/forensics-application/src/test/java/de/burger/forensics/application/service/GenerationRequestTest.java
@@ -1,0 +1,66 @@
+package de.burger.forensics.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GenerationRequestTest {
+
+    @Test
+    void copiesOptionalCollections() {
+        GenerationRequest request = new GenerationRequest(
+            Path.of("src"),
+            "org.example.Helper",
+            true,
+            true,
+            List.of("com.example"),
+            1,
+            List.of("value")
+        );
+
+        assertThat(request.packagePrefixes()).containsExactly("com.example");
+        assertThat(request.trackedVariables()).containsExactly("value");
+    }
+
+    @Test
+    void replacesNullCollectionsWithEmptyLists() {
+        GenerationRequest request = new GenerationRequest(
+            Path.of("src"),
+            "org.example.Helper",
+            true,
+            true,
+            null,
+            0,
+            null
+        );
+
+        assertThat(request.packagePrefixes()).isEmpty();
+        assertThat(request.trackedVariables()).isEmpty();
+    }
+
+    @Test
+    void requiresMandatoryFields() {
+        assertThatThrownBy(() -> new GenerationRequest(
+            null,
+            "helper",
+            true,
+            true,
+            List.of(),
+            0,
+            List.of()
+        )).isInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new GenerationRequest(
+            Path.of("src"),
+            null,
+            true,
+            true,
+            List.of(),
+            0,
+            List.of()
+        )).isInstanceOf(NullPointerException.class);
+    }
+}

--- a/forensics-btmgen/forensics-domain/src/test/java/de/burger/forensics/domain/model/RuleIdFactoryTest.java
+++ b/forensics-btmgen/forensics-domain/src/test/java/de/burger/forensics/domain/model/RuleIdFactoryTest.java
@@ -1,0 +1,43 @@
+package de.burger.forensics.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RuleIdFactoryTest {
+
+    private final SourceLocation location = new SourceLocation("com.example.Demo", "test", 42);
+
+    @Test
+    void createsDeterministicIdFromScanEvent() {
+        ScanEvent event = new ScanEvent(location, "test()", RuleType.IF_TRUE, "value > 0", "java");
+
+        RuleId id1 = RuleIdFactory.from(event, "value > 0");
+        RuleId id2 = RuleIdFactory.from(event, "value > 0");
+
+        assertThat(id1.value()).isEqualTo(id2.value()).hasSize(32);
+    }
+
+    @Test
+    void createsIdFromLocationAndType() {
+        RuleId id = RuleIdFactory.from(location, RuleType.ENTRY);
+
+        assertThat(id.value()).isNotBlank().hasSize(32);
+    }
+
+    @Test
+    void rejectsNullArguments() {
+        ScanEvent event = new ScanEvent(location, "test()", RuleType.IF_TRUE, "value > 0", "java");
+
+        assertThatThrownBy(() -> RuleIdFactory.from(null, "foo"))
+            .isInstanceOf(NullPointerException.class);
+        assertThatCode(() -> RuleIdFactory.from(event, null))
+            .doesNotThrowAnyException();
+        assertThatThrownBy(() -> RuleIdFactory.from((SourceLocation) null, RuleType.ENTRY))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> RuleIdFactory.from(location, null))
+            .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/forensics-btmgen/forensics-domain/src/test/java/de/burger/forensics/domain/model/RuleIdTest.java
+++ b/forensics-btmgen/forensics-domain/src/test/java/de/burger/forensics/domain/model/RuleIdTest.java
@@ -1,0 +1,21 @@
+package de.burger.forensics.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class RuleIdTest {
+
+    @Test
+    void rejectsBlankValues() {
+        assertThatThrownBy(() -> new RuleId(" "))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void acceptsNonBlankValues() {
+        assertThatCode(() -> new RuleId("abc"))
+            .doesNotThrowAnyException();
+    }
+}

--- a/forensics-btmgen/forensics-domain/src/test/java/de/burger/forensics/domain/strategy/DefaultStrategyFactoryTest.java
+++ b/forensics-btmgen/forensics-domain/src/test/java/de/burger/forensics/domain/strategy/DefaultStrategyFactoryTest.java
@@ -16,6 +16,27 @@ class DefaultStrategyFactoryTest {
     }
 
     @Test
+    void selectsLogicalStrategyWhenExpressionContainsLogicalOperators() {
+        ConditionStrategy strategy = factory.from("a && b || c");
+        assertThat(strategy).isInstanceOf(LogicalExprStrategy.class);
+        assertThat(strategy.toBytemanIf()).isEqualTo("a && b || c");
+    }
+
+    @Test
+    void selectsInstanceOfStrategyWhenExpressionContainsInstanceOf() {
+        ConditionStrategy strategy = factory.from("value instanceof String");
+        assertThat(strategy).isInstanceOf(InstanceOfStrategy.class);
+        assertThat(strategy.toBytemanIf()).isEqualTo("value instanceof String");
+    }
+
+    @Test
+    void returnsGenericStrategyForBlankExpressions() {
+        ConditionStrategy strategy = factory.from("   ");
+        assertThat(strategy).isInstanceOf(GenericUnsafeStrategy.class);
+        assertThat(strategy.toBytemanIf()).isEqualTo("true");
+    }
+
+    @Test
     void fallsBackToGenericStrategyOtherwise() {
         ConditionStrategy strategy = factory.from("counter > 0");
         assertThat(strategy).isInstanceOf(GenericUnsafeStrategy.class);

--- a/forensics-btmgen/forensics-domain/src/test/java/de/burger/forensics/domain/strategy/SafeModeDecoratorTest.java
+++ b/forensics-btmgen/forensics-domain/src/test/java/de/burger/forensics/domain/strategy/SafeModeDecoratorTest.java
@@ -1,0 +1,51 @@
+package de.burger.forensics.domain.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import de.burger.forensics.domain.model.RuleId;
+import org.junit.jupiter.api.Test;
+
+class SafeModeDecoratorTest {
+
+    @Test
+    void wrapsDelegateExpressionWithSafeEvalCall() {
+        ConditionStrategy delegate = () -> "value > 0";
+        SafeModeDecorator decorator = new SafeModeDecorator(delegate, "org.example.SafeEval", "rule-1");
+
+        assertThat(decorator.toBytemanIf())
+            .isEqualTo("org.example.SafeEval.eval(\"rule-1\",\"value > 0\",(value > 0))");
+    }
+
+    @Test
+    void escapesQuotesAndBackslashes() {
+        ConditionStrategy delegate = () -> "text\\\"";
+        SafeModeDecorator decorator = new SafeModeDecorator(delegate, "org.example.SafeEval", "rule-2");
+
+        assertThat(decorator.toBytemanIf())
+            .contains("text\\\\\\\"");
+    }
+
+    @Test
+    void rejectsNullArguments() {
+        ConditionStrategy delegate = () -> "true";
+
+        assertThatThrownBy(() -> new SafeModeDecorator(null, "h", "id"))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new SafeModeDecorator(delegate, null, "id"))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new SafeModeDecorator(delegate, "h", null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void safeModeUtilityWrapsDelegate() {
+        ConditionStrategy delegate = () -> "flag";
+
+        ConditionStrategy wrapped = SafeMode.wrap(delegate, "org.example.SafeEval", new RuleId("abc"));
+
+        assertThat(wrapped.toBytemanIf())
+            .contains("org.example.SafeEval.eval")
+            .contains("abc");
+    }
+}

--- a/forensics-btmgen/forensics-domain/src/test/java/de/burger/forensics/domain/strategy/StrategyImplementationsTest.java
+++ b/forensics-btmgen/forensics-domain/src/test/java/de/burger/forensics/domain/strategy/StrategyImplementationsTest.java
@@ -1,0 +1,45 @@
+package de.burger.forensics.domain.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class StrategyImplementationsTest {
+
+    @Test
+    void genericStrategyReturnsRawExpression() {
+        GenericUnsafeStrategy strategy = new GenericUnsafeStrategy("flag");
+        assertThat(strategy.toBytemanIf()).isEqualTo("flag");
+    }
+
+    @Test
+    void logicalStrategyReturnsRawExpression() {
+        LogicalExprStrategy strategy = new LogicalExprStrategy("a && b");
+        assertThat(strategy.toBytemanIf()).isEqualTo("a && b");
+    }
+
+    @Test
+    void nullCheckStrategyReturnsRawExpression() {
+        NullCheckStrategy strategy = new NullCheckStrategy("value != null");
+        assertThat(strategy.toBytemanIf()).isEqualTo("value != null");
+    }
+
+    @Test
+    void instanceOfStrategyReturnsRawExpression() {
+        InstanceOfStrategy strategy = new InstanceOfStrategy("obj instanceof String");
+        assertThat(strategy.toBytemanIf()).isEqualTo("obj instanceof String");
+    }
+
+    @Test
+    void strategiesRejectNullInput() {
+        assertThatThrownBy(() -> new GenericUnsafeStrategy(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new LogicalExprStrategy(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new NullCheckStrategy(null))
+            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new InstanceOfStrategy(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/forensics-btmgen/forensics-plugin/src/main/resources/logback.xml
+++ b/forensics-btmgen/forensics-plugin/src/main/resources/logback.xml
@@ -4,6 +4,7 @@
       <pattern>%d{ISO8601} %-5level [%X{cid}] %logger - %msg%n</pattern>
     </encoder>
   </appender>
+  <logger name="org.aspectj" level="INFO"/>
   <logger name="decision-trace" level="INFO"/>
   <root level="INFO">
     <appender-ref ref="STDOUT"/>

--- a/forensics-btmgen/forensics-plugin/src/test/java/de/burger/forensics/plugin/BtmGenExtensionTest.java
+++ b/forensics-btmgen/forensics-plugin/src/test/java/de/burger/forensics/plugin/BtmGenExtensionTest.java
@@ -1,0 +1,26 @@
+package de.burger.forensics.plugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+class BtmGenExtensionTest {
+
+    @Test
+    void providesConventionsForAllProperties() {
+        var project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply("de.burger.forensics.btmgen");
+
+        BtmGenExtension extension = project.getExtensions().getByType(BtmGenExtension.class);
+
+        assertThat(extension.getSrcDirs().get()).containsExactly("src/main/java");
+        assertThat(extension.getPackagePrefixes().get()).isEmpty();
+        assertThat(extension.getHelperFqn().get()).isEqualTo("org.example.trace.SafeEval");
+        assertThat(extension.getSafeMode().get()).isTrue();
+        assertThat(extension.getIncludeEntryExit().get()).isTrue();
+        assertThat(extension.getIncludeTimestamp().get()).isTrue();
+        assertThat(extension.getMinBranchesPerMethod().get()).isZero();
+        assertThat(extension.getOutputDirectory().get().getAsFile().getName()).isEqualTo("forensics");
+    }
+}

--- a/forensics-btmgen/forensics-plugin/src/test/java/de/burger/forensics/plugin/io/BtmFileWriterTest.java
+++ b/forensics-btmgen/forensics-plugin/src/test/java/de/burger/forensics/plugin/io/BtmFileWriterTest.java
@@ -1,0 +1,57 @@
+package de.burger.forensics.plugin.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class BtmFileWriterTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void writesTimestampHeaderWhenEnabled() throws IOException {
+        Clock fixedClock = Clock.fixed(Instant.parse("2024-01-01T12:34:56Z"), ZoneOffset.UTC);
+        BtmFileWriter writer = new BtmFileWriter(fixedClock);
+        Path output = tempDir.resolve("logs/rules.btm");
+
+        writer.write(output, true, "org.example.Helper", List.of("RULE one"));
+
+        String content = Files.readString(output);
+        assertThat(content)
+            .contains("# Generated at 2024-01-01T12:34:56Z")
+            .contains("# Helper: org.example.Helper")
+            .contains("RULE one");
+    }
+
+    @Test
+    void omitsTimestampWhenDisabled() throws IOException {
+        Clock fixedClock = Clock.fixed(Instant.parse("2024-01-01T12:34:56Z"), ZoneOffset.UTC);
+        BtmFileWriter writer = new BtmFileWriter(fixedClock);
+        Path output = tempDir.resolve("rules.btm");
+
+        writer.write(output, false, "helper", List.of());
+
+        List<String> lines = Files.readAllLines(output);
+        assertThat(lines.getFirst()).isEqualTo("# Generated rules");
+    }
+
+    @Test
+    void createsMissingDirectories() throws IOException {
+        Clock fixedClock = Clock.fixed(Instant.parse("2024-01-01T12:34:56Z"), ZoneOffset.UTC);
+        BtmFileWriter writer = new BtmFileWriter(fixedClock);
+        Path output = tempDir.resolve("nested/path/rules.btm");
+
+        writer.write(output, true, "helper", List.of("RULE two"));
+
+        assertThat(Files.exists(output)).isTrue();
+    }
+}

--- a/forensics-btmgen/forensics-plugin/src/test/java/de/burger/it/infrastructure/logging/MethodLoggingAspectTest.java
+++ b/forensics-btmgen/forensics-plugin/src/test/java/de/burger/it/infrastructure/logging/MethodLoggingAspectTest.java
@@ -1,0 +1,207 @@
+package de.burger.it.infrastructure.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.JoinPoint.StaticPart;
+import org.aspectj.lang.Signature;
+import org.aspectj.lang.reflect.SourceLocation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.MDC;
+
+class MethodLoggingAspectTest {
+
+    @TempDir
+    Path tempDir;
+
+    private final MethodLoggingAspect aspect = MethodLoggingAspect.aspectOf();
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("forensics.btmgen.logFile");
+        System.clearProperty("forensics.btmgen.logToFile");
+        MDC.clear();
+    }
+
+    @Test
+    void writesEntriesAndErrorsToLogFileWhenEnabled() throws IOException {
+        Path logFile = tempDir.resolve("aspect.log");
+        System.setProperty("forensics.btmgen.logFile", logFile.toString());
+        System.setProperty("forensics.btmgen.logToFile", "true");
+
+        TestJoinPoint jp = new TestJoinPoint(SampleService.class, "doWork", new Object[] {"alpha", null});
+
+        aspect.onEnter(jp);
+        aspect.onReturn(jp);
+        aspect.onThrow(jp, new IllegalStateException("boom"));
+
+        String content = Files.readString(logFile);
+        assertThat(content)
+            .contains("→ SampleService.doWork(..)")
+            .contains("← SampleService.doWork(..) OK")
+            .contains("failed");
+    }
+
+    @Test
+    void skipsFileLoggingWhenDisabled() {
+        Path logFile = tempDir.resolve("disabled.log");
+        System.setProperty("forensics.btmgen.logFile", logFile.toString());
+        System.setProperty("forensics.btmgen.logToFile", "false");
+
+        TestJoinPoint jp = new TestJoinPoint(SampleService.class, "noop", new Object[] {});
+
+        aspect.onEnter(jp);
+
+        assertThat(Files.exists(logFile)).isFalse();
+    }
+
+    private static final class SampleService {
+        void doWork() {
+        }
+    }
+
+    private static final class TestJoinPoint implements JoinPoint {
+        private final Object[] args;
+        private final Signature signature;
+
+        TestJoinPoint(Class<?> declaringType, String method, Object[] args) {
+            this.args = args;
+            this.signature = new SimpleSignature(declaringType, method);
+        }
+
+        @Override
+        public Object[] getArgs() {
+            return args;
+        }
+
+        @Override
+        public Signature getSignature() {
+            return signature;
+        }
+
+        @Override
+        public Object getTarget() {
+            return null;
+        }
+
+        @Override
+        public Object getThis() {
+            return null;
+        }
+
+        @Override
+        public String getKind() {
+            return "method-execution";
+        }
+
+        @Override
+        public StaticPart getStaticPart() {
+            return new StaticPart() {
+                @Override
+                public int getId() {
+                    return 0;
+                }
+
+                @Override
+                public String getKind() {
+                    return "method-execution";
+                }
+
+                @Override
+                public Signature getSignature() {
+                    return signature;
+                }
+
+                @Override
+                public SourceLocation getSourceLocation() {
+                    return null;
+                }
+
+                @Override
+                public String toString() {
+                    return signature.toString();
+                }
+
+                @Override
+                public String toShortString() {
+                    return signature.toShortString();
+                }
+
+                @Override
+                public String toLongString() {
+                    return signature.toLongString();
+                }
+            };
+        }
+
+        @Override
+        public SourceLocation getSourceLocation() {
+            return null;
+        }
+
+        @Override
+        public String toShortString() {
+            return signature.toShortString();
+        }
+
+        @Override
+        public String toLongString() {
+            return signature.toLongString();
+        }
+
+        @Override
+        public String toString() {
+            return signature.toString();
+        }
+    }
+
+    private static final class SimpleSignature implements Signature {
+        private final Class<?> declaringType;
+        private final String method;
+
+        SimpleSignature(Class<?> declaringType, String method) {
+            this.declaringType = declaringType;
+            this.method = method;
+        }
+
+        @Override
+        public String toShortString() {
+            return declaringType.getSimpleName() + "." + method + "(..)";
+        }
+
+        @Override
+        public String toLongString() {
+            return toShortString();
+        }
+
+        @Override
+        public String toString() {
+            return toShortString();
+        }
+
+        @Override
+        public String getName() {
+            return method;
+        }
+
+        @Override
+        public int getModifiers() {
+            return 0;
+        }
+
+        @Override
+        public Class<?> getDeclaringType() {
+            return declaringType;
+        }
+
+        @Override
+        public String getDeclaringTypeName() {
+            return declaringType.getName();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add extensive unit coverage for domain strategies and identifier factories to verify edge cases and validation
- expand application and adapter tests to exercise rule generation paths across all rule types
- cover Gradle plugin utilities and logging, including re-enabling AspectJ logging in Logback and verifying the aspect writes to disk

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68daaeef08608326a5b8676ef7758c8e