### PR TITLE
Fix void method exit tracing rule

### DIFF
--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategy.java
@@ -15,7 +15,7 @@ public final class MethodExitRuleStrategy extends AbstractBytemanStrategy implem
             AT EXIT
             %s
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.onExitVoid(%s.class, "%s");
+                de.burger.forensics.infrastructure.rt.RtTrace.onExit(%s.class, "%s", null);
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),

--- a/src/test/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategyTest.java
+++ b/src/test/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategyTest.java
@@ -1,0 +1,28 @@
+package de.burger.forensics.plugin.btmgen.render.impl;
+
+import de.burger.forensics.plugin.btmgen.render.api.RuleParams;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MethodExitRuleStrategyTest {
+
+    @Test
+    void rendersVoidExitUsingOnExitWithNullResult() {
+        RuleParams params = new RuleParams(
+                "ruleId",
+                "com.example.Foo",
+                "doWork",
+                "()V",
+                null,
+                null,
+                null
+        );
+
+        String rule = new MethodExitRuleStrategy().render(params);
+
+        assertThat(rule)
+                .contains("de.burger.forensics.infrastructure.rt.RtTrace.onExit(com.example.Foo.class, \"doWork\", null);")
+                .doesNotContain("onExitVoid");
+    }
+}


### PR DESCRIPTION
## Summary
- update the Byteman METHOD_EXIT rule template to invoke `RtTrace.onExit` with a null result instead of a non-existent helper
- add a regression test that ensures the template renders the expected tracing call for void methods

## Testing
- gradle test *(fails: the supplied Gradle 8.14.3 launcher rejects the -javaagent flag expected by the build script)*

------
https://chatgpt.com/codex/tasks/task_e_68e037971a788326bafff8d8781be9ce