### PR TITLE
Ensure generateBtmRules configures an output directory

### DIFF
--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/BtmGenPlugin.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/BtmGenPlugin.java
@@ -36,10 +36,20 @@ public class BtmGenPlugin implements Plugin<@NotNull Project> {
                     }
 
                     if (ext.getOutputFile().isPresent()) {
-                        t.getOutputFile().fileValue(ext.getOutputFile().get());
+                        var file = ext.getOutputFile().get();
+                        t.getOutputFile().fileValue(file);
+                        if (file.getParentFile() != null) {
+                            t.getOutputDir().fileValue(file.getParentFile());
+                        }
                     } else {
                         t.getOutputFile().convention(
                                 project.getLayout().getBuildDirectory().file("forensics/forensics.btm")
+                        );
+                    }
+
+                    if (!t.getOutputDir().isPresent()) {
+                        t.getOutputDir().convention(
+                                project.getLayout().getBuildDirectory().dir("forensics")
                         );
                     }
                 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTask.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTask.java
@@ -64,7 +64,11 @@ public abstract class GenerateBtmTask extends DefaultTask {
             getSourceRoot().set(ext.getSourceRoot().get());
         }
         if (ext.getOutputFile().isPresent()) {
-            getOutputFile().fileValue(ext.getOutputFile().get());
+            var file = ext.getOutputFile().get();
+            getOutputFile().fileValue(file);
+            if (file.getParentFile() != null) {
+                getOutputDir().fileValue(file.getParentFile());
+            }
         }
     }
 
@@ -149,6 +153,9 @@ public abstract class GenerateBtmTask extends DefaultTask {
         getSourceRoot().convention(layout.getProjectDirectory().dir("src/main/java"));
         getOutputFile().convention(
                 layout.getBuildDirectory().file("forensics/forensics.btm")
+        );
+        getOutputDir().convention(
+                layout.getBuildDirectory().dir("forensics")
         );
     }
 


### PR DESCRIPTION
## Summary
- propagate the configured output file to the task's output directory when the extension supplies a custom location
- add a default output directory convention so the task always satisfies Gradle's validation

## Testing
- ./gradlew clean generateBtmRules --info *(fails: wrapper jar missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e0414650b08326947a1bd571a6fed0