### PR TITLE
Fix Gradle 9.0 compatibility issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.internal.os.OperatingSystem
-
 plugins {
     `java-library`
     `java-gradle-plugin`
@@ -88,7 +86,6 @@ tasks.withType<Test>().configureEach {
         val weaverJar = aspectjAgent.resolve().firstOrNull { it.name.startsWith("aspectjweaver") }
             ?: throw GradleException("aspectjweaver*.jar nicht gefunden. Füge 'aspectjAgent(libs.aspectj.weaver)' hinzu.")
         val arg = javaAgentArg(weaverJar)
-        println("Attaching AspectJ agent for tests: $arg")
         listOf(
             arg,
             "-XX:+PrintCommandLineFlags"
@@ -120,13 +117,10 @@ tasks.test {
             ?: error("AspectJ weaver not found on testRuntimeClasspath. Add testRuntimeOnly(\"org.aspectj:aspectjweaver:<ver>\").")
 
         // Windows: Pfad mit Leerzeichen MUSS in Anführungszeichen
-        val os = OperatingSystem.current()
-        val agentArg =
-            if (os.isWindows) "-javaagent:\"${weaverFile.absolutePath}\""
-            else "-javaagent=${weaverFile.absolutePath}"
+        val agentArg = javaAgentArg(weaverFile)
+        println("Attaching AspectJ agent for tests: $agentArg")
 
         jvmArgs(
-            agentArg,
             "-Xshare:off" // ok, optional
         )
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -114,6 +114,7 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
+CLASSPATH="\\\"\\\""
 
 
 # Determine the Java command to use to start the JVM.
@@ -171,6 +172,7 @@ fi
 # For Cygwin or MSYS, switch paths to Windows format before running java
 if "$cygwin" || "$msys" ; then
     APP_HOME=$( cygpath --path --mixed "$APP_HOME" )
+    CLASSPATH=$( cygpath --path --mixed "$CLASSPATH" )
 
     JAVACMD=$( cygpath --unix "$JAVACMD" )
 
@@ -210,6 +212,7 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
+        -classpath "$CLASSPATH" \
         -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
         "$@"
 

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -70,10 +70,11 @@ goto fail
 :execute
 @rem Setup the command line
 
+set CLASSPATH=
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/BtmGenPlugin.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/BtmGenPlugin.java
@@ -2,12 +2,8 @@ package de.burger.forensics.plugin.btmgen.gradle;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.file.RegularFile;
-import org.gradle.api.file.Directory;
 import org.gradle.api.tasks.TaskProvider;
 import org.jetbrains.annotations.NotNull;
-
-import java.io.File;
 
 /**
  * Compatible wiring when the extension exposes Property<File> rather than DirectoryProperty/RegularFileProperty.
@@ -17,11 +13,11 @@ public final class BtmGenPlugin implements Plugin<@NotNull Project> {
 
     @Override
     public void apply(Project project) {
-        final BtmGenLegacyFileExtension ext = project.getExtensions()
-                .create("btmGen", BtmGenLegacyFileExtension.class);
+        final BtmGenExtension ext = project.getExtensions()
+                .create("btmGen", BtmGenExtension.class);
 
         // Register task
-        TaskProvider<@NotNull GenerateBtmTask> task = project.getTasks().register(
+        TaskProvider<@NotNull GenerateBtmTask> taskProvider = project.getTasks().register(
                 "generateBtmRules",
                 GenerateBtmTask.class,
                 t -> {
@@ -60,9 +56,10 @@ public final class BtmGenPlugin implements Plugin<@NotNull Project> {
                 }
         );
 
-                    task.getSourceRoot().finalizeValueOnRead();
-                    task.getOutputFile().finalizeValueOnRead();
-                });
+        taskProvider.configure(task -> {
+            task.getSourceRoot().finalizeValueOnRead();
+            task.getOutputFile().finalizeValueOnRead();
+        });
 
         project.getTasks().matching(t -> t.getName().equals("build"))
                 .configureEach(t -> t.dependsOn(taskProvider));


### PR DESCRIPTION
## Summary
- update the Gradle wrapper metadata and scripts for Gradle 9.0.0
- adjust BtmGenPlugin to register tasks against the new extension API and finalize values lazily
- fix JVM agent wiring for tests so `-javaagent` arguments are Gradle 9 compatible

## Testing
- `./gradle-9.0.0/bin/gradle --console=plain build`


------
https://chatgpt.com/codex/tasks/task_e_68e0453d86c8832682572425466ddd61