### PR TITLE
Use task registration in GenerateBtmTaskTest

### DIFF
--- a/src/test/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTaskTest.java
+++ b/src/test/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTaskTest.java
@@ -26,7 +26,7 @@ class GenerateBtmTaskTest {
         var project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
         Files.createDirectories(tempDir.resolve("src/main/java"));
 
-        var task = project.getTasks().create("generateBtmMinimal", GenerateBtmTask.class);
+        var task = project.getTasks().register("generateBtmMinimal", GenerateBtmTask.class).get();
 
         var extension = project.getObjects().newInstance(BtmGenExtension.class);
         var strategy = new RecordingStrategy("CUSTOM");
@@ -74,7 +74,7 @@ class GenerateBtmTaskTest {
                 "  }\n" +
                 "}\n");
 
-        var task = project.getTasks().create("generateBtmScan", GenerateBtmTask.class);
+        var task = project.getTasks().register("generateBtmScan", GenerateBtmTask.class).get();
 
         var extension = project.getObjects().newInstance(BtmGenExtension.class);
         Map<String, RecordingStrategy> strategies = registerDefaultStrategies(extension);


### PR DESCRIPTION
## Summary
- replace deprecated TaskContainer#create calls in GenerateBtmTaskTest with register().get()
- keep tests functionally identical while avoiding deprecation warnings

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e05813b4a4832689aa6486c5b333b9