### PR TITLE
Avoid reapplying conventions on finalized GenerateBtmTask properties

### DIFF
--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTask.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTask.java
@@ -150,13 +150,19 @@ public abstract class GenerateBtmTask extends DefaultTask {
 
     private void applyDefaultConventions() {
         ProjectLayout layout = getProject().getLayout();
-        getSourceRoot().convention(layout.getProjectDirectory().dir("src/main/java"));
-        getOutputFile().convention(
-                layout.getBuildDirectory().file("forensics/forensics.btm")
-        );
-        getOutputDir().convention(
-                layout.getBuildDirectory().dir("forensics")
-        );
+        if (!getSourceRoot().isPresent()) {
+            getSourceRoot().convention(layout.getProjectDirectory().dir("src/main/java"));
+        }
+        if (!getOutputFile().isPresent()) {
+            getOutputFile().convention(
+                    layout.getBuildDirectory().file("forensics/forensics.btm")
+            );
+        }
+        if (!getOutputDir().isPresent()) {
+            getOutputDir().convention(
+                    layout.getBuildDirectory().dir("forensics")
+            );
+        }
     }
 
     private boolean hasMinimalInputs() {


### PR DESCRIPTION
## Summary
- only apply default conventions for GenerateBtmTask when the corresponding property is unset to prevent touching finalized values
- keep runtime execution from attempting to mutate already-finalized inputs and outputs

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e0594eb4dc83268d864ad8d74fa2da