### PR TITLE
Allow configuring helper FQN for generated Byteman rules

### DIFF
--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/BtmGenExtension.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/BtmGenExtension.java
@@ -1,5 +1,6 @@
 package de.burger.forensics.plugin.btmgen.gradle;
 
+import de.burger.forensics.plugin.btmgen.render.api.RuleParams;
 import de.burger.forensics.plugin.btmgen.render.spi.StrategyRegistries;
 import de.burger.forensics.plugin.btmgen.render.spi.StrategyRegistry;
 import org.gradle.api.model.ObjectFactory;
@@ -19,6 +20,7 @@ public abstract class BtmGenExtension {
     private final Property<@NotNull File> outputFile;
     private final Property<@NotNull String> includes;
     private final Property<@NotNull File> sourceRootFile;
+    private final Property<@NotNull String> helperFqn;
 
     @Inject
     public BtmGenExtension(ObjectFactory objects) {
@@ -26,8 +28,10 @@ public abstract class BtmGenExtension {
         this.outputFile = objects.property(File.class);
         this.includes = objects.property(String.class);
         this.sourceRootFile = objects.property(File.class);
+        this.helperFqn = objects.property(String.class);
         this.sourceRoot.convention(new File("src/main/java"));
         this.outputFile.convention(new File("build/forensics/forensics.btm"));
+        this.helperFqn.convention(RuleParams.DEFAULT_HELPER_FQN);
     }
 
     /** Strategy registry used by tasks to render rules. */
@@ -43,4 +47,7 @@ public abstract class BtmGenExtension {
     public Property<@NotNull String> getIncludes() { return includes; }
 
     public Property<@NotNull File> getSourceRootFile() { return sourceRootFile; }
+
+    /** Fully qualified helper class invoked from generated rules. */
+    public Property<@NotNull String> getHelperFqn() { return helperFqn; }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTask.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTask.java
@@ -49,6 +49,7 @@ public abstract class GenerateBtmTask extends DefaultTask {
     @Input @Optional public abstract Property<@NotNull Integer>  getMinBranchesPerMethod();
     @Input @Optional public abstract Property<@NotNull Boolean> getLogToFile();
     @Input @Optional public abstract Property<@NotNull String>  getLogFilePath();
+    @Input @Optional public abstract Property<@NotNull String>  getHelperFqn();
 
     // Provided by plugin (or set manually in build script)
     private BtmGenExtension extension;
@@ -70,6 +71,7 @@ public abstract class GenerateBtmTask extends DefaultTask {
                 getOutputDir().fileValue(file.getParentFile());
             }
         }
+        getHelperFqn().convention(ext.getHelperFqn());
     }
 
     @TaskAction
@@ -100,7 +102,8 @@ public abstract class GenerateBtmTask extends DefaultTask {
                     getMethodDesc().getOrNull(),
                     getClassName().get() + "#" + getMethodName().get(),
                     null,
-                    null
+                    null,
+                    resolveHelperFqn()
             );
             allRules.add(renderer.render(templateIdOrDefault(), params));
         } else {
@@ -189,44 +192,48 @@ public abstract class GenerateBtmTask extends DefaultTask {
         for (MethodSig m : methods) {
             // Always add method enter/exit
             rules.add(renderer.render("METHOD_ENTER", new RuleParams(
-                    "METHOD_ENTER", m.className, m.methodName, m.methodDesc, m.displayName(), null, null
+                    "METHOD_ENTER", m.className, m.methodName, m.methodDesc, m.displayName(), null, null, resolveHelperFqn()
             )));
             rules.add(renderer.render("METHOD_EXIT", new RuleParams(
-                    "METHOD_EXIT", m.className, m.methodName, m.methodDesc, m.displayName(), null, null
+                    "METHOD_EXIT", m.className, m.methodName, m.methodDesc, m.displayName(), null, null, resolveHelperFqn()
             )));
 
             // Return / Throw
             if (m.hasReturn) {
                 rules.add(renderer.render("RETURN", new RuleParams(
-                        "RETURN", m.className, m.methodName, m.methodDesc, m.displayName(), null, null
+                        "RETURN", m.className, m.methodName, m.methodDesc, m.displayName(), null, null, resolveHelperFqn()
                 )));
             }
             if (m.hasThrow) {
                 rules.add(renderer.render("THROW", new RuleParams(
-                        "THROW", m.className, m.methodName, m.methodDesc, m.displayName(), null, null
+                        "THROW", m.className, m.methodName, m.methodDesc, m.displayName(), null, null, resolveHelperFqn()
                 )));
             }
 
             // If / Switch – map both branches & switch markers (coarse grained)
             if (hasIf) {
                 rules.add(renderer.render("IF_TRUE", new RuleParams(
-                        "IF_TRUE", m.className, m.methodName, m.methodDesc, m.displayName(), "true", null
+                        "IF_TRUE", m.className, m.methodName, m.methodDesc, m.displayName(), "true", null, resolveHelperFqn()
                 )));
                 rules.add(renderer.render("IF_FALSE", new RuleParams(
-                        "IF_FALSE", m.className, m.methodName, m.methodDesc, m.displayName(), "false", null
+                        "IF_FALSE", m.className, m.methodName, m.methodDesc, m.displayName(), "false", null, resolveHelperFqn()
                 )));
             }
             if (hasSwitch) {
                 rules.add(renderer.render("SWITCH", new RuleParams(
-                        "SWITCH", m.className, m.methodName, m.methodDesc, m.displayName(), null, null
+                        "SWITCH", m.className, m.methodName, m.methodDesc, m.displayName(), null, null, resolveHelperFqn()
                 )));
                 rules.add(renderer.render("SWITCH_CASE", new RuleParams(
-                        "SWITCH_CASE", m.className, m.methodName, m.methodDesc, m.displayName(), null, null
+                        "SWITCH_CASE", m.className, m.methodName, m.methodDesc, m.displayName(), null, null, resolveHelperFqn()
                 )));
             }
         }
 
         return rules;
+    }
+
+    private String resolveHelperFqn() {
+        return getHelperFqn().getOrElse(RuleParams.DEFAULT_HELPER_FQN);
     }
 
     private String findPackage(String code) {

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/api/RuleParams.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/api/RuleParams.java
@@ -8,5 +8,14 @@ public record RuleParams(
         String methodDesc,   // optional descriptor/signature, may be null
         String displayName,  // human label (optional)
         String condition,    // optional IF guard (Byteman expression)
-        String sqlHint       // optional SQL preview for JDBC template
-) { }
+        String sqlHint,      // optional SQL preview for JDBC template
+        String helperFqn     // helper implementation invoked from the rule
+) {
+    public static final String DEFAULT_HELPER_FQN = "de.burger.forensics.infrastructure.rt.RtTrace";
+
+    public RuleParams {
+        if (helperFqn == null || helperFqn.isBlank()) {
+            helperFqn = DEFAULT_HELPER_FQN;
+        }
+    }
+}

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfFalseRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfFalseRuleStrategy.java
@@ -16,14 +16,14 @@ public final class IfFalseRuleStrategy extends AbstractBytemanStrategy implement
             AT ENTRY
             IF %s
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.onBranch(%s.class, "%s", "IF_FALSE");
+                %s.onBranch(%s.class, "%s", "IF_FALSE");
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
                 cond,
-                p.className(), p.methodName()
+                p.helperFqn(), p.className(), p.methodName()
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfTrueRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfTrueRuleStrategy.java
@@ -17,14 +17,14 @@ public final class IfTrueRuleStrategy extends AbstractBytemanStrategy implements
             AT ENTRY
             IF %s
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.onBranch(%s.class, "%s", "IF_TRUE");
+                %s.onBranch(%s.class, "%s", "IF_TRUE");
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
                 cond,
-                p.className(), p.methodName()
+                p.helperFqn(), p.className(), p.methodName()
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/JdbcExecuteRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/JdbcExecuteRuleStrategy.java
@@ -19,7 +19,7 @@ public final class JdbcExecuteRuleStrategy extends AbstractBytemanStrategy imple
             AT ENTRY
             IF true
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.ioBegin("JDBC", "%s#%s%s");
+                %s.ioBegin("JDBC", "%s#%s%s");
             ENDRULE
 
             RULE %s-end : jdbc io end
@@ -28,11 +28,11 @@ public final class JdbcExecuteRuleStrategy extends AbstractBytemanStrategy imple
             AT EXIT
             IF true
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.ioEnd("JDBC", "%s#%s%s");
+                %s.ioEnd("JDBC", "%s#%s%s");
             ENDRULE
             """.formatted(
-                id, target, methods, target, methods, hint,
-                id, target, methods, target, methods, hint
+                id, target, methods, p.helperFqn(), target, methods, hint,
+                id, target, methods, p.helperFqn(), target, methods, hint
         );
     }
 

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodEnterRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodEnterRuleStrategy.java
@@ -15,14 +15,14 @@ public final class MethodEnterRuleStrategy extends AbstractBytemanStrategy imple
             AT ENTRY
             %s
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.onEnter(%s.class, "%s", $* );
+                %s.onEnter(%s.class, "%s", $* );
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
                 ifClause(p.condition()),
-                p.className(), p.methodName()
+                p.helperFqn(), p.className(), p.methodName()
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategy.java
@@ -15,14 +15,14 @@ public final class MethodExitRuleStrategy extends AbstractBytemanStrategy implem
             AT EXIT
             %s
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.onExit(%s.class, "%s", null);
+                %s.onExit(%s.class, "%s", null);
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
                 ifClause(p.condition()),
-                p.className(), p.methodName()
+                p.helperFqn(), p.className(), p.methodName()
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ReturnRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ReturnRuleStrategy.java
@@ -15,14 +15,14 @@ public final class ReturnRuleStrategy extends AbstractBytemanStrategy implements
             AT EXIT
             %s
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.onExit(%s.class, "%s", $! );
+                %s.onExit(%s.class, "%s", $! );
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
                 ifClause(p.condition()),
-                p.className(), p.methodName()
+                p.helperFqn(), p.className(), p.methodName()
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchCaseRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchCaseRuleStrategy.java
@@ -17,13 +17,13 @@ public final class SwitchCaseRuleStrategy extends AbstractBytemanStrategy implem
             AT ENTRY
             IF true
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.onCase(%s.class, "%s", "%s");
+                %s.onCase(%s.class, "%s", "%s");
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
-                p.className(), p.methodName(), label
+                p.helperFqn(), p.className(), p.methodName(), label
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchRuleStrategy.java
@@ -16,13 +16,13 @@ public final class SwitchRuleStrategy extends AbstractBytemanStrategy implements
             AT ENTRY
             IF true
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.onSwitch(%s.class, "%s", %s );
+                %s.onSwitch(%s.class, "%s", %s );
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
-                p.className(), p.methodName(),
+                p.helperFqn(), p.className(), p.methodName(),
                 p.displayName() == null ? "\"\"" : "\"" + esc(p.displayName()) + "\""
         );
     }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThreadLifecycleRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThreadLifecycleRuleStrategy.java
@@ -16,7 +16,7 @@ public final class ThreadLifecycleRuleStrategy extends AbstractBytemanStrategy i
             AT ENTRY
             IF true
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.threadFork($0.getName());
+                %s.threadFork($0.getName());
             ENDRULE
 
             RULE %s-join : thread join
@@ -25,8 +25,8 @@ public final class ThreadLifecycleRuleStrategy extends AbstractBytemanStrategy i
             AT ENTRY
             IF true
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.threadJoin($0.getName());
+                %s.threadJoin($0.getName());
             ENDRULE
-            """.formatted(id, id);
+            """.formatted(id, p.helperFqn(), id, p.helperFqn());
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThrowRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThrowRuleStrategy.java
@@ -15,13 +15,14 @@ public final class ThrowRuleStrategy extends AbstractBytemanStrategy implements 
             AT THROW
             %s
             DO
-                de.burger.forensics.infrastructure.rt.RtTrace.onException($^);
+                %s.onException($^);
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
-                ifClause(p.condition())
+                ifClause(p.condition()),
+                p.helperFqn()
         );
     }
 }

--- a/src/test/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTaskTest.java
+++ b/src/test/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTaskTest.java
@@ -48,6 +48,7 @@ class GenerateBtmTaskTest {
         assertEquals("com.example.Foo", params.className());
         assertEquals("bar", params.methodName());
         assertEquals("(I)V", params.methodDesc());
+        assertEquals(RuleParams.DEFAULT_HELPER_FQN, params.helperFqn());
 
         assertTrue(Files.exists(outputFile), "Output file should be created");
         String content = Files.readString(outputFile);
@@ -121,6 +122,35 @@ class GenerateBtmTaskTest {
                 strategies.get("IF_FALSE").calls.stream().map(RuleParams::condition).toList());
         assertEquals(2, strategies.get("SWITCH").calls.size());
         assertEquals(2, strategies.get("SWITCH_CASE").calls.size());
+
+        strategies.values().forEach(recording ->
+                recording.calls.forEach(params ->
+                        assertEquals(RuleParams.DEFAULT_HELPER_FQN, params.helperFqn())));
+    }
+
+    @Test
+    void generateRespectsCustomHelperFqn(@TempDir Path tempDir) throws IOException {
+        var project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
+        Files.createDirectories(tempDir.resolve("src/main/java"));
+
+        var task = project.getTasks().register("generateBtmCustomHelper", GenerateBtmTask.class).get();
+
+        var extension = project.getObjects().newInstance(BtmGenExtension.class);
+        var strategy = new RecordingStrategy("CUSTOM");
+        extension.setRegistry(StrategyRegistry.builder().register(strategy).build());
+        extension.getSourceRoot().set(tempDir.resolve("src/main/java").toFile());
+        Path outputFile = tempDir.resolve("build/forensics/custom-helper.btm");
+        extension.getOutputFile().set(outputFile.toFile());
+        extension.getHelperFqn().set("com.example.Helper");
+
+        task.setExtension(extension);
+        task.getTemplateId().set("CUSTOM");
+        task.getClassName().set("com.example.Foo");
+        task.getMethodName().set("bar");
+
+        task.generate();
+
+        assertEquals("com.example.Helper", strategy.calls.getFirst().helperFqn());
     }
 
     private static Map<String, RecordingStrategy> registerDefaultStrategies(BtmGenExtension extension) {

--- a/src/test/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategyTest.java
+++ b/src/test/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategyTest.java
@@ -16,7 +16,8 @@ class MethodExitRuleStrategyTest {
                 "()V",
                 null,
                 null,
-                null
+                null,
+                RuleParams.DEFAULT_HELPER_FQN
         );
 
         String rule = new MethodExitRuleStrategy().render(params);
@@ -24,5 +25,24 @@ class MethodExitRuleStrategyTest {
         assertThat(rule)
                 .contains("de.burger.forensics.infrastructure.rt.RtTrace.onExit(com.example.Foo.class, \"doWork\", null);")
                 .doesNotContain("onExitVoid");
+    }
+
+    @Test
+    void usesProvidedHelperFqn() {
+        RuleParams params = new RuleParams(
+                "ruleId",
+                "com.example.Foo",
+                "doWork",
+                "()V",
+                null,
+                null,
+                null,
+                "com.example.Helper"
+        );
+
+        String rule = new MethodExitRuleStrategy().render(params);
+
+        assertThat(rule)
+                .contains("com.example.Helper.onExit(com.example.Foo.class, \"doWork\", null);");
     }
 }


### PR DESCRIPTION
## Summary
- add a configurable helperFqn to the extension/task and plumb it through RuleParams
- render all rule strategies using the helper provided by callers instead of hard-coded RtTrace
- extend tests to cover default and custom helper configurations

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e05d9e21748326aca86c7a7f9da81a