### PR TITLE
Use Byteman helper for generated tracing rules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
 
     // Runtime
     compileOnly(libs.slf4j.api)
+    compileOnly(libs.byteman)
 
     aspectjAgent(libs.aspectj.weaver)
     implementation(libs.aspectj.rt)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ bytebuddy = "1.14.12"
 slf4j    = "2.0.17"
 logback  = "1.5.18"
 mockito = "5.13.0"
+byteman = "4.0.23"
 
 # Gradle plugins
 #gradle-plugin-publish = "2.0.0"
@@ -53,3 +54,4 @@ byte-buddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "b
 
 # Assertions
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+byteman = { module = "org.jboss.byteman:byteman", version.ref = "byteman" }

--- a/src/main/java/de/burger/forensics/infrastructure/rt/RtTrace.java
+++ b/src/main/java/de/burger/forensics/infrastructure/rt/RtTrace.java
@@ -108,6 +108,39 @@ public final class RtTrace {
         ), null);
     }
 
+    /** Convenience: record an if/else branch hit. */
+    public static void onBranch(Class<?> clazz, String method, String branch) {
+        if (!ENABLED) return;
+        emit(RtEvent.BRANCH_TAKEN, Map.of(
+                "class", safeClass(clazz),
+                "method", method,
+                "kind", "if",
+                "branch", branch
+        ), null);
+    }
+
+    /** Convenience: record entering a switch statement. */
+    public static void onSwitch(Class<?> clazz, String method, String displayName) {
+        if (!ENABLED) return;
+        emit(RtEvent.BRANCH_TAKEN, Map.of(
+                "class", safeClass(clazz),
+                "method", method,
+                "kind", "switch",
+                "label", Objects.toString(displayName, "")
+        ), null);
+    }
+
+    /** Convenience: record which switch case matched. */
+    public static void onCase(Class<?> clazz, String method, String label) {
+        if (!ENABLED) return;
+        emit(RtEvent.BRANCH_TAKEN, Map.of(
+                "class", safeClass(clazz),
+                "method", method,
+                "kind", "case",
+                "label", Objects.toString(label, "")
+        ), null);
+    }
+
     /** Convenience: variable set. */
     public static void varSet(String name, Object value) {
         if (!ENABLED) return;

--- a/src/main/java/de/burger/forensics/infrastructure/rt/RtTraceHelper.java
+++ b/src/main/java/de/burger/forensics/infrastructure/rt/RtTraceHelper.java
@@ -1,0 +1,54 @@
+package de.burger.forensics.infrastructure.rt;
+
+import org.jboss.byteman.rule.Rule;
+import org.jboss.byteman.rule.helper.Helper;
+
+/**
+ * Lightweight Byteman helper delegating to {@link RtTrace}.
+ */
+public final class RtTraceHelper extends Helper {
+
+    public RtTraceHelper(Rule rule) {
+        super(rule);
+    }
+
+    public void onEnter(Class<?> clazz, String method, Object... args) {
+        RtTrace.onEnter(clazz, method, args);
+    }
+
+    public void onExit(Class<?> clazz, String method, Object result) {
+        RtTrace.onExit(clazz, method, result);
+    }
+
+    public void onBranch(Class<?> clazz, String method, String branchLabel) {
+        RtTrace.onBranch(clazz, method, branchLabel);
+    }
+
+    public void onSwitch(Class<?> clazz, String method, String displayName) {
+        RtTrace.onSwitch(clazz, method, displayName);
+    }
+
+    public void onCase(Class<?> clazz, String method, String label) {
+        RtTrace.onCase(clazz, method, label);
+    }
+
+    public void onException(Throwable throwable) {
+        RtTrace.onException(throwable);
+    }
+
+    public void ioBegin(String op, String target) {
+        RtTrace.ioBegin(op, target);
+    }
+
+    public void ioEnd(String op, String target) {
+        RtTrace.ioEnd(op, target);
+    }
+
+    public void threadFork(String threadName) {
+        RtTrace.threadFork(threadName);
+    }
+
+    public void threadJoin(String threadName) {
+        RtTrace.threadJoin(threadName);
+    }
+}

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/api/RuleParams.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/api/RuleParams.java
@@ -11,7 +11,7 @@ public record RuleParams(
         String sqlHint,      // optional SQL preview for JDBC template
         String helperFqn     // helper implementation invoked from the rule
 ) {
-    public static final String DEFAULT_HELPER_FQN = "de.burger.forensics.infrastructure.rt.RtTrace";
+    public static final String DEFAULT_HELPER_FQN = "de.burger.forensics.infrastructure.rt.RtTraceHelper";
 
     public RuleParams {
         if (helperFqn == null || helperFqn.isBlank()) {

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfFalseRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfFalseRuleStrategy.java
@@ -13,17 +13,19 @@ public final class IfFalseRuleStrategy extends AbstractBytemanStrategy implement
             RULE %s : if-false %s#%s
             CLASS %s
             METHOD %s
+            HELPER %s
             AT ENTRY
             IF %s
             DO
-                %s.onBranch(%s.class, "%s", "IF_FALSE");
+                helper().onBranch(%s.class, "%s", "IF_FALSE");
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
+                p.helperFqn(),
                 cond,
-                p.helperFqn(), p.className(), p.methodName()
+                p.className(), p.methodName()
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfTrueRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfTrueRuleStrategy.java
@@ -14,17 +14,19 @@ public final class IfTrueRuleStrategy extends AbstractBytemanStrategy implements
             RULE %s : if-true %s#%s
             CLASS %s
             METHOD %s
+            HELPER %s
             AT ENTRY
             IF %s
             DO
-                %s.onBranch(%s.class, "%s", "IF_TRUE");
+                helper().onBranch(%s.class, "%s", "IF_TRUE");
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
+                p.helperFqn(),
                 cond,
-                p.helperFqn(), p.className(), p.methodName()
+                p.className(), p.methodName()
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/JdbcExecuteRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/JdbcExecuteRuleStrategy.java
@@ -16,19 +16,21 @@ public final class JdbcExecuteRuleStrategy extends AbstractBytemanStrategy imple
             RULE %s-begin : jdbc io begin
             CLASS %s
             METHOD %s(..)
+            HELPER %s
             AT ENTRY
             IF true
             DO
-                %s.ioBegin("JDBC", "%s#%s%s");
+                helper().ioBegin("JDBC", "%s#%s%s");
             ENDRULE
 
             RULE %s-end : jdbc io end
             CLASS %s
             METHOD %s(..)
+            HELPER %s
             AT EXIT
             IF true
             DO
-                %s.ioEnd("JDBC", "%s#%s%s");
+                helper().ioEnd("JDBC", "%s#%s%s");
             ENDRULE
             """.formatted(
                 id, target, methods, p.helperFqn(), target, methods, hint,

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodEnterRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodEnterRuleStrategy.java
@@ -12,17 +12,19 @@ public final class MethodEnterRuleStrategy extends AbstractBytemanStrategy imple
             RULE %s : enter %s#%s
             CLASS %s
             METHOD %s
+            HELPER %s
             AT ENTRY
             %s
             DO
-                %s.onEnter(%s.class, "%s", $* );
+                helper().onEnter(%s.class, "%s", $* );
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
+                p.helperFqn(),
                 ifClause(p.condition()),
-                p.helperFqn(), p.className(), p.methodName()
+                p.className(), p.methodName()
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategy.java
@@ -12,17 +12,19 @@ public final class MethodExitRuleStrategy extends AbstractBytemanStrategy implem
             RULE %s : exit %s#%s
             CLASS %s
             METHOD %s
+            HELPER %s
             AT EXIT
             %s
             DO
-                %s.onExit(%s.class, "%s", null);
+                helper().onExit(%s.class, "%s", null);
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
+                p.helperFqn(),
                 ifClause(p.condition()),
-                p.helperFqn(), p.className(), p.methodName()
+                p.className(), p.methodName()
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ReturnRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ReturnRuleStrategy.java
@@ -12,17 +12,19 @@ public final class ReturnRuleStrategy extends AbstractBytemanStrategy implements
             RULE %s : return %s#%s
             CLASS %s
             METHOD %s
+            HELPER %s
             AT EXIT
             %s
             DO
-                %s.onExit(%s.class, "%s", $! );
+                helper().onExit(%s.class, "%s", $! );
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
+                p.helperFqn(),
                 ifClause(p.condition()),
-                p.helperFqn(), p.className(), p.methodName()
+                p.className(), p.methodName()
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchCaseRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchCaseRuleStrategy.java
@@ -14,16 +14,18 @@ public final class SwitchCaseRuleStrategy extends AbstractBytemanStrategy implem
             RULE %s : switch-case %s#%s
             CLASS %s
             METHOD %s
+            HELPER %s
             AT ENTRY
             IF true
             DO
-                %s.onCase(%s.class, "%s", "%s");
+                helper().onCase(%s.class, "%s", "%s");
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
-                p.helperFqn(), p.className(), p.methodName(), label
+                p.helperFqn(),
+                p.className(), p.methodName(), label
         );
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchRuleStrategy.java
@@ -13,16 +13,18 @@ public final class SwitchRuleStrategy extends AbstractBytemanStrategy implements
             RULE %s : switch %s#%s
             CLASS %s
             METHOD %s
+            HELPER %s
             AT ENTRY
             IF true
             DO
-                %s.onSwitch(%s.class, "%s", %s );
+                helper().onSwitch(%s.class, "%s", %s );
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
-                p.helperFqn(), p.className(), p.methodName(),
+                p.helperFqn(),
+                p.className(), p.methodName(),
                 p.displayName() == null ? "\"\"" : "\"" + esc(p.displayName()) + "\""
         );
     }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThreadLifecycleRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThreadLifecycleRuleStrategy.java
@@ -13,19 +13,21 @@ public final class ThreadLifecycleRuleStrategy extends AbstractBytemanStrategy i
             RULE %s-start : thread start
             CLASS java.lang.Thread
             METHOD start()
+            HELPER %s
             AT ENTRY
             IF true
             DO
-                %s.threadFork($0.getName());
+                helper().threadFork($0.getName());
             ENDRULE
 
             RULE %s-join : thread join
             CLASS java.lang.Thread
             METHOD join(..)
+            HELPER %s
             AT ENTRY
             IF true
             DO
-                %s.threadJoin($0.getName());
+                helper().threadJoin($0.getName());
             ENDRULE
             """.formatted(id, p.helperFqn(), id, p.helperFqn());
     }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThrowRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThrowRuleStrategy.java
@@ -12,17 +12,18 @@ public final class ThrowRuleStrategy extends AbstractBytemanStrategy implements 
             RULE %s : throw %s#%s
             CLASS %s
             METHOD %s
+            HELPER %s
             AT THROW
             %s
             DO
-                %s.onException($^);
+                helper().onException($^);
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),
                 p.className(),
                 methodSig(p.methodName(), p.methodDesc()),
-                ifClause(p.condition()),
-                p.helperFqn()
+                p.helperFqn(),
+                ifClause(p.condition())
         );
     }
 }

--- a/src/test/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategyTest.java
+++ b/src/test/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategyTest.java
@@ -23,7 +23,8 @@ class MethodExitRuleStrategyTest {
         String rule = new MethodExitRuleStrategy().render(params);
 
         assertThat(rule)
-                .contains("de.burger.forensics.infrastructure.rt.RtTrace.onExit(com.example.Foo.class, \"doWork\", null);")
+                .contains("HELPER de.burger.forensics.infrastructure.rt.RtTraceHelper")
+                .contains("helper().onExit(com.example.Foo.class, \"doWork\", null);")
                 .doesNotContain("onExitVoid");
     }
 
@@ -43,6 +44,7 @@ class MethodExitRuleStrategyTest {
         String rule = new MethodExitRuleStrategy().render(params);
 
         assertThat(rule)
-                .contains("com.example.Helper.onExit(com.example.Foo.class, \"doWork\", null);");
+                .contains("HELPER com.example.Helper")
+                .contains("helper().onExit(com.example.Foo.class, \"doWork\", null);");
     }
 }


### PR DESCRIPTION
## Summary
- add a Byteman-compatible helper that delegates to the existing `RtTrace` runtime
- update rule renderers to declare the helper and call it instead of static `RtTrace` methods
- extend the runtime API and build configuration to support the new helper entry points

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e061308fd083268051297e5190ff55