### PR TITLE
Normalize helper class names for rule generation

### DIFF
--- a/src/main/java/de/burger/forensics/application/service/GenerationRequest.java
+++ b/src/main/java/de/burger/forensics/application/service/GenerationRequest.java
@@ -14,9 +14,14 @@ public record GenerationRequest(Path root,
                                 List<String> packagePrefixes,
                                 int minBranches,
                                 List<String> trackedVariables) {
+    public static final String DEFAULT_HELPER_FQCN = "de.burger.forensics.infrastructure.rt.RtTraceHelper";
+
     public GenerationRequest {
         Objects.requireNonNull(root, "root");
-        Objects.requireNonNull(helperFqcn, "helperFqcn");
+        helperFqcn = Objects.requireNonNull(helperFqcn, "helperFqcn");
+        if (helperFqcn.isBlank()) {
+            helperFqcn = DEFAULT_HELPER_FQCN;
+        }
         packagePrefixes = packagePrefixes == null ? List.of() : List.copyOf(packagePrefixes);
         trackedVariables = trackedVariables == null ? List.of() : List.copyOf(trackedVariables);
     }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTask.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTask.java
@@ -233,7 +233,8 @@ public abstract class GenerateBtmTask extends DefaultTask {
     }
 
     private String resolveHelperFqn() {
-        return getHelperFqn().getOrElse(RuleParams.DEFAULT_HELPER_FQN);
+        String helper = getHelperFqn().getOrElse(RuleParams.DEFAULT_HELPER_FQN);
+        return (helper == null || helper.isBlank()) ? RuleParams.DEFAULT_HELPER_FQN : helper;
     }
 
     private String findPackage(String code) {

--- a/src/test/java/de/burger/forensics/application/service/GenerationRequestTest.java
+++ b/src/test/java/de/burger/forensics/application/service/GenerationRequestTest.java
@@ -43,6 +43,21 @@ class GenerationRequestTest {
     }
 
     @Test
+    void replacesBlankHelperWithDefault() {
+        GenerationRequest request = new GenerationRequest(
+            Path.of("src"),
+            "  ",
+            true,
+            true,
+            List.of(),
+            0,
+            List.of()
+        );
+
+        assertThat(request.helperFqcn()).isEqualTo(GenerationRequest.DEFAULT_HELPER_FQCN);
+    }
+
+    @Test
     void requiresMandatoryFields() {
         assertThatThrownBy(() -> new GenerationRequest(
             null,

--- a/src/test/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTaskTest.java
+++ b/src/test/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTaskTest.java
@@ -153,6 +153,31 @@ class GenerateBtmTaskTest {
         assertEquals("com.example.Helper", strategy.calls.getFirst().helperFqn());
     }
 
+    @Test
+    void generateNormalizesBlankHelperFqn(@TempDir Path tempDir) throws IOException {
+        var project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
+        Files.createDirectories(tempDir.resolve("src/main/java"));
+
+        var task = project.getTasks().register("generateBtmBlankHelper", GenerateBtmTask.class).get();
+
+        var extension = project.getObjects().newInstance(BtmGenExtension.class);
+        var strategy = new RecordingStrategy("CUSTOM");
+        extension.setRegistry(StrategyRegistry.builder().register(strategy).build());
+        extension.getSourceRoot().set(tempDir.resolve("src/main/java").toFile());
+        Path outputFile = tempDir.resolve("build/forensics/blank-helper.btm");
+        extension.getOutputFile().set(outputFile.toFile());
+        extension.getHelperFqn().set("   ");
+
+        task.setExtension(extension);
+        task.getTemplateId().set("CUSTOM");
+        task.getClassName().set("com.example.Foo");
+        task.getMethodName().set("bar");
+
+        task.generate();
+
+        assertEquals(RuleParams.DEFAULT_HELPER_FQN, strategy.calls.getFirst().helperFqn());
+    }
+
     private static Map<String, RecordingStrategy> registerDefaultStrategies(BtmGenExtension extension) {
         Map<String, RecordingStrategy> strategies = new HashMap<>();
         var builder = StrategyRegistry.builder();


### PR DESCRIPTION
## Summary
- default blank helper class names in `GenerationRequest` to the runtime trace helper and cover with tests
- ensure the Gradle Byteman generation task falls back to the default helper when configured with blanks

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e064f6c93c8326a3919b1d5e2aae51