### PR TITLE
Add runtime helper classpath wiring for Gradle plugin

### DIFF
--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/BtmGenPlugin.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/BtmGenPlugin.java
@@ -1,9 +1,15 @@
 package de.burger.forensics.plugin.btmgen.gradle;
 
+import de.burger.forensics.plugin.btmgen.gradle.internal.PluginRuntimeLocator;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.TaskProvider;
 import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.util.Optional;
 
 /**
  * Compatible wiring when the extension exposes Property<File> rather than DirectoryProperty/RegularFileProperty.
@@ -60,7 +66,27 @@ public final class BtmGenPlugin implements Plugin<@NotNull Project> {
             task.getOutputFile().finalizeValueOnRead();
         });
 
+        project.getPlugins().withType(JavaPlugin.class, ignored -> attachRuntimeHelper(project));
+
         project.getTasks().matching(t -> t.getName().equals("build"))
                 .configureEach(t -> t.dependsOn(taskProvider));
+    }
+
+    private void attachRuntimeHelper(Project project) {
+        Optional<File> runtimeArtifact = PluginRuntimeLocator.locateFor(BtmGenPlugin.class);
+        if (runtimeArtifact.isEmpty()) {
+            project.getLogger().warn("forensics-btmgen: Unable to locate runtime helper artifact; helper will not be added to classpath.");
+            return;
+        }
+
+        FileCollection helperFiles = project.files(runtimeArtifact.get());
+        addDependencyIfPresent(project, "runtimeOnly", helperFiles);
+        addDependencyIfPresent(project, "testRuntimeOnly", helperFiles);
+    }
+
+    private void addDependencyIfPresent(Project project, String configurationName, FileCollection files) {
+        if (project.getConfigurations().findByName(configurationName) != null) {
+            project.getDependencies().add(configurationName, files);
+        }
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/internal/PluginRuntimeLocator.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/internal/PluginRuntimeLocator.java
@@ -1,0 +1,40 @@
+package de.burger.forensics.plugin.btmgen.gradle.internal;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Utility to locate the jar or classes directory that contains the plugin runtime helper.
+ */
+public final class PluginRuntimeLocator {
+
+    private PluginRuntimeLocator() {
+    }
+
+    public static Optional<File> locateFor(Class<?> anchor) {
+        if (anchor == null) {
+            return Optional.empty();
+        }
+
+        URL location = anchor.getProtectionDomain().getCodeSource() != null
+                ? anchor.getProtectionDomain().getCodeSource().getLocation()
+                : null;
+        if (location == null) {
+            return Optional.empty();
+        }
+
+        try {
+            Path path = Path.of(location.toURI());
+            if (!Files.exists(path)) {
+                return Optional.empty();
+            }
+            return Optional.of(path.toFile());
+        } catch (URISyntaxException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/de/burger/forensics/plugin/btmgen/gradle/BtmGenPluginTest.java
+++ b/src/test/java/de/burger/forensics/plugin/btmgen/gradle/BtmGenPluginTest.java
@@ -1,0 +1,29 @@
+package de.burger.forensics.plugin.btmgen.gradle;
+
+import de.burger.forensics.plugin.btmgen.gradle.internal.PluginRuntimeLocator;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BtmGenPluginTest {
+
+    @Test
+    void appliesRuntimeHelperToJavaConfigurations() {
+        Project project = ProjectBuilder.builder().build();
+        project.getPlugins().apply("java");
+        project.getPlugins().apply("de.burger.forensics.btmgen");
+
+        Optional<File> runtimeArtifact = PluginRuntimeLocator.locateFor(BtmGenPlugin.class);
+        assertTrue(runtimeArtifact.isPresent(), "Expected plugin runtime artifact to be locatable");
+
+        assertTrue(project.getConfigurations().getByName("runtimeClasspath").resolve().contains(runtimeArtifact.get()),
+                "runtimeClasspath should include the plugin runtime helper");
+        assertTrue(project.getConfigurations().getByName("testRuntimeClasspath").resolve().contains(runtimeArtifact.get()),
+                "testRuntimeClasspath should include the plugin runtime helper");
+    }
+}


### PR DESCRIPTION
## Summary
- add runtime helper wiring so Java projects automatically get the plugin helper on their runtime and test classpaths
- introduce an internal locator utility to resolve the plugin artifact used for the helper
- cover the runtime helper wiring with a dedicated plugin unit test

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e06893cc248326ac84b4a0d9177443