### PR TITLE
Allow Byteman to subclass RtTraceHelper

### DIFF
--- a/src/main/java/de/burger/forensics/infrastructure/rt/RtTraceHelper.java
+++ b/src/main/java/de/burger/forensics/infrastructure/rt/RtTraceHelper.java
@@ -6,7 +6,7 @@ import org.jboss.byteman.rule.helper.Helper;
 /**
  * Lightweight Byteman helper delegating to {@link RtTrace}.
  */
-public final class RtTraceHelper extends Helper {
+public class RtTraceHelper extends Helper {
 
     public RtTraceHelper(Rule rule) {
         super(rule);


### PR DESCRIPTION
## Summary
- remove the final modifier from RtTraceHelper so Byteman can extend it

## Testing
- ./gradlew test


------
https://chatgpt.com/codex/tasks/task_e_68e06bfd72dc8326abf6e6c74f5e24b5