### PR TITLE
Call helper methods directly in BTM templates

### DIFF
--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfFalseRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfFalseRuleStrategy.java
@@ -17,7 +17,7 @@ public final class IfFalseRuleStrategy extends AbstractBytemanStrategy implement
             AT ENTRY
             IF %s
             DO
-                helper().onBranch(%s.class, "%s", "IF_FALSE");
+                onBranch(%s.class, "%s", "IF_FALSE");
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfTrueRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/IfTrueRuleStrategy.java
@@ -18,7 +18,7 @@ public final class IfTrueRuleStrategy extends AbstractBytemanStrategy implements
             AT ENTRY
             IF %s
             DO
-                helper().onBranch(%s.class, "%s", "IF_TRUE");
+                onBranch(%s.class, "%s", "IF_TRUE");
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/JdbcExecuteRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/JdbcExecuteRuleStrategy.java
@@ -20,7 +20,7 @@ public final class JdbcExecuteRuleStrategy extends AbstractBytemanStrategy imple
             AT ENTRY
             IF true
             DO
-                helper().ioBegin("JDBC", "%s#%s%s");
+                ioBegin("JDBC", "%s#%s%s");
             ENDRULE
 
             RULE %s-end : jdbc io end
@@ -30,7 +30,7 @@ public final class JdbcExecuteRuleStrategy extends AbstractBytemanStrategy imple
             AT EXIT
             IF true
             DO
-                helper().ioEnd("JDBC", "%s#%s%s");
+                ioEnd("JDBC", "%s#%s%s");
             ENDRULE
             """.formatted(
                 id, target, methods, p.helperFqn(), target, methods, hint,

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodEnterRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodEnterRuleStrategy.java
@@ -16,7 +16,7 @@ public final class MethodEnterRuleStrategy extends AbstractBytemanStrategy imple
             AT ENTRY
             %s
             DO
-                helper().onEnter(%s.class, "%s", $* );
+                onEnter(%s.class, "%s", $* );
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategy.java
@@ -16,7 +16,7 @@ public final class MethodExitRuleStrategy extends AbstractBytemanStrategy implem
             AT EXIT
             %s
             DO
-                helper().onExit(%s.class, "%s", null);
+                onExit(%s.class, "%s", null);
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ReturnRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ReturnRuleStrategy.java
@@ -16,7 +16,7 @@ public final class ReturnRuleStrategy extends AbstractBytemanStrategy implements
             AT EXIT
             %s
             DO
-                helper().onExit(%s.class, "%s", $! );
+                onExit(%s.class, "%s", $! );
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchCaseRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchCaseRuleStrategy.java
@@ -18,7 +18,7 @@ public final class SwitchCaseRuleStrategy extends AbstractBytemanStrategy implem
             AT ENTRY
             IF true
             DO
-                helper().onCase(%s.class, "%s", "%s");
+                onCase(%s.class, "%s", "%s");
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/SwitchRuleStrategy.java
@@ -17,7 +17,7 @@ public final class SwitchRuleStrategy extends AbstractBytemanStrategy implements
             AT ENTRY
             IF true
             DO
-                helper().onSwitch(%s.class, "%s", %s );
+                onSwitch(%s.class, "%s", %s );
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThreadLifecycleRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThreadLifecycleRuleStrategy.java
@@ -17,7 +17,7 @@ public final class ThreadLifecycleRuleStrategy extends AbstractBytemanStrategy i
             AT ENTRY
             IF true
             DO
-                helper().threadFork($0.getName());
+                threadFork($0.getName());
             ENDRULE
 
             RULE %s-join : thread join
@@ -27,7 +27,7 @@ public final class ThreadLifecycleRuleStrategy extends AbstractBytemanStrategy i
             AT ENTRY
             IF true
             DO
-                helper().threadJoin($0.getName());
+                threadJoin($0.getName());
             ENDRULE
             """.formatted(id, p.helperFqn(), id, p.helperFqn());
     }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThrowRuleStrategy.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/render/impl/ThrowRuleStrategy.java
@@ -16,7 +16,7 @@ public final class ThrowRuleStrategy extends AbstractBytemanStrategy implements 
             AT THROW
             %s
             DO
-                helper().onException($^);
+                onException($^);
             ENDRULE
             """.formatted(
                 safeId(p.id()), or(p.displayName(), p.className()), p.methodName(),

--- a/src/test/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTaskTest.java
+++ b/src/test/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTaskTest.java
@@ -129,6 +129,84 @@ class GenerateBtmTaskTest {
     }
 
     @Test
+    void generatedRulesInvokeHelpersDirectly(@TempDir Path tempDir) throws IOException {
+        var project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
+        Path srcDir = tempDir.resolve("src/main/java/com/example");
+        Files.createDirectories(srcDir);
+        Path javaFile = srcDir.resolve("Sample.java");
+        Files.writeString(javaFile, """
+                package com.example;
+                public class Sample {
+                  public int alpha() {
+                    if (true) { }
+                    switch (1) { case 1 -> {} }
+                    return 1;
+                  }
+                  public void beta() {
+                    if (false) { }
+                    switch (2) { case 2 -> {} }
+                    throw new IllegalStateException();
+                  }
+                }
+                """);
+
+        Path scanOutput = tempDir.resolve("build/forensics/helpers-scan.btm");
+        var scanTask = project.getTasks().register("generateBtmHelpersScan", GenerateBtmTask.class).get();
+        var scanExtension = project.getObjects().newInstance(BtmGenExtension.class);
+        scanExtension.getSourceRoot().set(tempDir.resolve("src/main/java").toFile());
+        scanExtension.getOutputFile().set(scanOutput.toFile());
+        scanTask.setExtension(scanExtension);
+
+        scanTask.generate();
+
+        assertTrue(Files.exists(scanOutput));
+        String scanContent = Files.readString(scanOutput);
+        assertFalse(scanContent.contains("helper()."));
+        assertTrue(scanContent.contains("onEnter("));
+        assertTrue(scanContent.contains("onExit("));
+        assertTrue(scanContent.contains("onBranch("));
+        assertTrue(scanContent.contains("onSwitch("));
+        assertTrue(scanContent.contains("onCase("));
+        assertTrue(scanContent.contains("onException("));
+
+        Path jdbcOutput = tempDir.resolve("build/forensics/helpers-jdbc.btm");
+        var jdbcTask = project.getTasks().register("generateBtmHelpersJdbc", GenerateBtmTask.class).get();
+        var jdbcExtension = project.getObjects().newInstance(BtmGenExtension.class);
+        jdbcExtension.getSourceRoot().set(tempDir.resolve("src/main/java").toFile());
+        jdbcExtension.getOutputFile().set(jdbcOutput.toFile());
+        jdbcTask.setExtension(jdbcExtension);
+        jdbcTask.getTemplateId().set("JDBC_EXECUTE");
+        jdbcTask.getClassName().set("java.sql.Statement");
+        jdbcTask.getMethodName().set("execute");
+
+        jdbcTask.generate();
+
+        assertTrue(Files.exists(jdbcOutput));
+        String jdbcContent = Files.readString(jdbcOutput);
+        assertFalse(jdbcContent.contains("helper()."));
+        assertTrue(jdbcContent.contains("ioBegin("));
+        assertTrue(jdbcContent.contains("ioEnd("));
+
+        Path threadOutput = tempDir.resolve("build/forensics/helpers-thread.btm");
+        var threadTask = project.getTasks().register("generateBtmHelpersThread", GenerateBtmTask.class).get();
+        var threadExtension = project.getObjects().newInstance(BtmGenExtension.class);
+        threadExtension.getSourceRoot().set(tempDir.resolve("src/main/java").toFile());
+        threadExtension.getOutputFile().set(threadOutput.toFile());
+        threadTask.setExtension(threadExtension);
+        threadTask.getTemplateId().set("THREAD_LIFECYCLE");
+        threadTask.getClassName().set("java.lang.Thread");
+        threadTask.getMethodName().set("start");
+
+        threadTask.generate();
+
+        assertTrue(Files.exists(threadOutput));
+        String threadContent = Files.readString(threadOutput);
+        assertFalse(threadContent.contains("helper()."));
+        assertTrue(threadContent.contains("threadFork("));
+        assertTrue(threadContent.contains("threadJoin("));
+    }
+
+    @Test
     void generateRespectsCustomHelperFqn(@TempDir Path tempDir) throws IOException {
         var project = ProjectBuilder.builder().withProjectDir(tempDir.toFile()).build();
         Files.createDirectories(tempDir.resolve("src/main/java"));

--- a/src/test/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategyTest.java
+++ b/src/test/java/de/burger/forensics/plugin/btmgen/render/impl/MethodExitRuleStrategyTest.java
@@ -24,7 +24,8 @@ class MethodExitRuleStrategyTest {
 
         assertThat(rule)
                 .contains("HELPER de.burger.forensics.infrastructure.rt.RtTraceHelper")
-                .contains("helper().onExit(com.example.Foo.class, \"doWork\", null);")
+                .contains("onExit(com.example.Foo.class, \"doWork\", null);")
+                .doesNotContain("helper().")
                 .doesNotContain("onExitVoid");
     }
 
@@ -45,6 +46,7 @@ class MethodExitRuleStrategyTest {
 
         assertThat(rule)
                 .contains("HELPER com.example.Helper")
-                .contains("helper().onExit(com.example.Foo.class, \"doWork\", null);");
+                .contains("onExit(com.example.Foo.class, \"doWork\", null);")
+                .doesNotContain("helper().");
     }
 }


### PR DESCRIPTION
## Summary
- update all built-in rule templates to invoke helper methods without the helper() accessor
- refresh unit tests to expect direct helper calls and guard against the old helper() prefix
- add a generator task test to ensure produced BTM scripts omit helper() while still calling helper utilities

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e06edbd278832681beef7053fec7b1