### PR TITLE
fix: guard JavaParser symbol resolution

### DIFF
--- a/src/main/java/de/burger/forensics/adaptersupport/javaparser/DefaultTypeReferenceQualifier.java
+++ b/src/main/java/de/burger/forensics/adaptersupport/javaparser/DefaultTypeReferenceQualifier.java
@@ -136,16 +136,13 @@ public final class DefaultTypeReferenceQualifier implements TypeReferenceQualifi
                 && context.hasAmbiguousWildcardStaticCandidate(methodCall.getNameAsString())) {
             return java.util.Optional.empty();
         }
-        try {
+        return JavaParserResolutionGuard.resolve(() -> {
             var resolved = methodCall.resolve();
             if (resolved.isStatic()) {
-                String declaringType = resolved.declaringType().getQualifiedName();
-                return externalTypeName(declaringType, context);
+                return resolved.declaringType().getQualifiedName();
             }
-        } catch (RuntimeException ignored) {
-            // Unresolved or ambiguous method calls stay visible for validation diagnostics.
-        }
-        return java.util.Optional.empty();
+            return null;
+        }).flatMap(declaringType -> externalTypeName(declaringType, context));
     }
 
     private static Map<Range, String> resolvedFieldScopes(Expression expression, MethodScanContext context) {
@@ -160,12 +157,8 @@ public final class DefaultTypeReferenceQualifier implements TypeReferenceQualifi
                 && context.hasAmbiguousWildcardTypeCandidate(scope.getNameAsString())) {
             return java.util.Optional.empty();
         }
-        try {
-            return externalTypeName(declaringTypeName(fieldAccess.resolve()), context);
-        } catch (RuntimeException ignored) {
-            // Unresolved or ambiguous field accesses stay visible for validation diagnostics.
-        }
-        return java.util.Optional.empty();
+        return JavaParserResolutionGuard.resolve(() -> declaringTypeName(fieldAccess.resolve()))
+                .flatMap(declaringType -> externalTypeName(declaringType, context));
     }
 
     private static Map<Range, String> resolvedStaticValues(Expression expression, MethodScanContext context) {
@@ -179,13 +172,12 @@ public final class DefaultTypeReferenceQualifier implements TypeReferenceQualifi
         if (context.hasAmbiguousWildcardStaticCandidate(name.getNameAsString())) {
             return java.util.Optional.empty();
         }
-        try {
+        return JavaParserResolutionGuard.resolve(() -> {
             ResolvedValueDeclaration resolved = name.resolve();
             return externalTypeName(declaringTypeName(resolved), context)
-                    .map(declaringType -> declaringType + "." + resolved.getName());
-        } catch (RuntimeException ignored) {
-            return java.util.Optional.empty();
-        }
+                    .map(declaringType -> declaringType + "." + resolved.getName())
+                    .orElse(null);
+        });
     }
 
     private static String declaringTypeName(ResolvedValueDeclaration resolved) {

--- a/src/main/java/de/burger/forensics/adaptersupport/javaparser/InstanceFieldNormalizer.java
+++ b/src/main/java/de/burger/forensics/adaptersupport/javaparser/InstanceFieldNormalizer.java
@@ -25,7 +25,7 @@ public final class InstanceFieldNormalizer {
     Set<Range> identifyInstanceFieldRanges(Node scope, Set<String> localVariables) {
         Set<Range> ranges = new LinkedHashSet<>();
         scope.walk(NameExpr.class, name -> {
-            if (resolvesToInstanceField(name) || isLikelyInstanceField(name, name.getNameAsString(), localVariables)) {
+            if (isLikelyInstanceField(name, name.getNameAsString(), localVariables) || resolvesToInstanceField(name)) {
                 name.getRange().ifPresent(ranges::add);
             }
         });
@@ -40,12 +40,10 @@ public final class InstanceFieldNormalizer {
     }
 
     boolean resolvesToInstanceField(NameExpr name) {
-        try {
+        return JavaParserResolutionGuard.resolve(() -> {
             var resolved = name.resolve();
             return resolved.isField() && !resolved.asField().isStatic();
-        } catch (RuntimeException ignored) {
-            return false;
-        }
+        }).orElse(false);
     }
 
     boolean isLikelyInstanceField(NameExpr name, String identifier, Set<String> localVariables) {

--- a/src/main/java/de/burger/forensics/adaptersupport/javaparser/JavaParserResolutionGuard.java
+++ b/src/main/java/de/burger/forensics/adaptersupport/javaparser/JavaParserResolutionGuard.java
@@ -1,0 +1,21 @@
+package de.burger.forensics.adaptersupport.javaparser;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Protects optional JavaParser symbol resolution from recursive solver failures.
+ */
+final class JavaParserResolutionGuard {
+
+    private JavaParserResolutionGuard() {
+    }
+
+    static <T> Optional<T> resolve(Supplier<T> resolution) {
+        try {
+            return Optional.ofNullable(resolution.get());
+        } catch (StackOverflowError | RuntimeException ignored) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/de/burger/forensics/adaptersupport/javaparser/StaticFieldQualifier.java
+++ b/src/main/java/de/burger/forensics/adaptersupport/javaparser/StaticFieldQualifier.java
@@ -20,7 +20,7 @@ public final class StaticFieldQualifier {
     Set<Range> identifyStaticFieldRanges(Node scope, Set<String> localVariables) {
         Set<Range> ranges = new LinkedHashSet<>();
         scope.walk(NameExpr.class, name -> {
-            if (resolvesToStaticField(name) || isLikelyStaticField(name, name.getNameAsString(), localVariables)) {
+            if (isLikelyStaticField(name, name.getNameAsString(), localVariables) || resolvesToStaticField(name)) {
                 name.getRange().ifPresent(ranges::add);
             }
         });
@@ -37,14 +37,12 @@ public final class StaticFieldQualifier {
     }
 
     boolean resolvesToStaticField(NameExpr name) {
-        try {
+        return JavaParserResolutionGuard.resolve(() -> {
             var resolved = name.resolve();
             return resolved.isField()
                     && resolved.asField().isStatic()
                     && isDeclaredByCurrentType(name, resolved.asField().declaringType().getQualifiedName());
-        } catch (RuntimeException ignored) {
-            return false;
-        }
+        }).orElse(false);
     }
 
     boolean isLikelyStaticField(NameExpr name, String identifier, Set<String> localVariables) {

--- a/src/main/java/de/burger/forensics/adaptersupport/javaparser/scanner/JavaParserScanEventCollector.java
+++ b/src/main/java/de/burger/forensics/adaptersupport/javaparser/scanner/JavaParserScanEventCollector.java
@@ -21,8 +21,8 @@ public final class JavaParserScanEventCollector {
     static List<ScanEvent> collectSafely(JavaParser parser, Path file, MethodEventExtractor methodEventExtractor) {
         try {
             return collect(parser, file, methodEventExtractor);
-        } catch (IOException | RuntimeException ignored) {
-            // Ignore parsing issues to keep scanning resilient.
+        } catch (IOException | RuntimeException | StackOverflowError ignored) {
+            // Ignore parsing and symbol-resolution issues to keep scanning resilient.
             return List.of();
         }
     }

--- a/src/test/java/de/burger/forensics/adapters/javaparser/JavaParserScannerTest.java
+++ b/src/test/java/de/burger/forensics/adapters/javaparser/JavaParserScannerTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class JavaParserScannerTest {
 
@@ -187,6 +188,32 @@ class JavaParserScannerTest {
         List<ScanEvent> events = scanner.scan(tempDir).toList();
 
         assertThat(events).isEmpty();
+    }
+
+    @Test
+    void continuesWhenSymbolSolverSeesRecursiveTypes(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("Sample.java"), """
+            package example;
+
+            class A extends B {
+                int a;
+            }
+
+            class B extends A {
+                int b;
+            }
+
+            class Sample extends A {
+                void run() {
+                    if (a > 0) {
+                        System.out.println(a);
+                    }
+                }
+            }
+            """);
+
+        assertThatCode(() -> scanner.scan(tempDir).toList())
+            .doesNotThrowAnyException();
     }
 
     @Test

--- a/src/test/java/de/burger/forensics/adaptersupport/javaparser/InstanceFieldNormalizerTest.java
+++ b/src/test/java/de/burger/forensics/adaptersupport/javaparser/InstanceFieldNormalizerTest.java
@@ -6,11 +6,13 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.IfStmt;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class InstanceFieldNormalizerTest {
 
@@ -70,7 +72,48 @@ class InstanceFieldNormalizerTest {
         assertThat(normalizer.isLikelyInstanceField(local, "limit", Set.of("limit"))).isFalse();
     }
 
+    @Test
+    void supportsEnumInstanceFieldsAndRejectsEnumStaticFields() {
+        MethodDeclaration declaration = parseMethod("""
+            enum Sample {
+                ITEM;
+                private int value;
+                private static int STATIC_VALUE;
+                boolean check() {
+                    if (value > STATIC_VALUE) {}
+                    return true;
+                }
+            }
+            """);
+        Expression condition = declaration.findFirst(IfStmt.class).orElseThrow().getCondition();
+        NameExpr instanceField = condition.findFirst(NameExpr.class, name -> name.getNameAsString().equals("value")).orElseThrow();
+        NameExpr staticField = condition.findFirst(NameExpr.class, name -> name.getNameAsString().equals("STATIC_VALUE")).orElseThrow();
+
+        assertThat(normalizer.declaresInstanceField(instanceField, "value")).isTrue();
+        assertThat(normalizer.declaresInstanceField(staticField, "STATIC_VALUE")).isFalse();
+    }
+
+    @Test
+    void treatsStackOverflowDuringResolutionAsNonInstanceField() {
+        NameExpr name = new StackOverflowNameExpr("value");
+
+        assertThatCode(() -> assertThat(normalizer.resolvesToInstanceField(name)).isFalse())
+            .doesNotThrowAnyException();
+    }
+
     private MethodDeclaration parseMethod(String source) {
         return StaticJavaParser.parse(source).findFirst(MethodDeclaration.class).orElseThrow();
+    }
+
+    private static final class StackOverflowNameExpr extends NameExpr {
+
+        private StackOverflowNameExpr(String name) {
+            super(name);
+        }
+
+        @Override
+        public ResolvedValueDeclaration resolve() {
+            throw new StackOverflowError("simulated JavaParser recursion");
+        }
     }
 }

--- a/src/test/java/de/burger/forensics/adaptersupport/javaparser/JavaParserResolutionGuardTest.java
+++ b/src/test/java/de/burger/forensics/adaptersupport/javaparser/JavaParserResolutionGuardTest.java
@@ -1,0 +1,27 @@
+package de.burger.forensics.adaptersupport.javaparser;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaParserResolutionGuardTest {
+
+    @Test
+    void returnsResolvedValue() {
+        assertThat(JavaParserResolutionGuard.resolve(() -> "resolved")).contains("resolved");
+    }
+
+    @Test
+    void returnsEmptyForRuntimeResolutionFailure() {
+        assertThat(JavaParserResolutionGuard.resolve(() -> {
+            throw new IllegalStateException("unresolved");
+        })).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyForRecursiveSolverFailure() {
+        assertThat(JavaParserResolutionGuard.resolve(() -> {
+            throw new StackOverflowError("recursive symbol resolution");
+        })).isEmpty();
+    }
+}

--- a/src/test/java/de/burger/forensics/adaptersupport/javaparser/StaticFieldQualifierTest.java
+++ b/src/test/java/de/burger/forensics/adaptersupport/javaparser/StaticFieldQualifierTest.java
@@ -6,11 +6,13 @@ import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.stmt.IfStmt;
+import com.github.javaparser.resolution.declarations.ResolvedValueDeclaration;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class StaticFieldQualifierTest {
 
@@ -96,15 +98,18 @@ class StaticFieldQualifierTest {
         MethodDeclaration declaration = parseMethod("""
             enum Sample {
                 ITEM;
+                int value = 0;
                 static int VALUE = 1;
                 boolean check() {
-                    return VALUE > 0;
+                    return VALUE > value;
                 }
             }
             """);
         NameExpr staticField = declaration.findFirst(NameExpr.class, name -> name.getNameAsString().equals("VALUE")).orElseThrow();
+        NameExpr instanceField = declaration.findFirst(NameExpr.class, name -> name.getNameAsString().equals("value")).orElseThrow();
 
         assertThat(qualifier.declaresStaticField(staticField, "VALUE")).isTrue();
+        assertThat(qualifier.declaresStaticField(instanceField, "value")).isFalse();
         assertThat(qualifier.declaresStaticField(staticField, "")).isFalse();
         NameExpr missing = StaticJavaParser.parseExpression("missing").asNameExpr();
         assertThat(qualifier.resolvesToStaticField(missing)).isFalse();
@@ -117,7 +122,27 @@ class StaticFieldQualifierTest {
         assertThat(qualifier.qualifyStaticFieldAccess(name, Set.of())).isFalse();
     }
 
+    @Test
+    void treatsStackOverflowDuringResolutionAsNonStaticField() {
+        NameExpr name = new StackOverflowNameExpr("VALUE");
+
+        assertThatCode(() -> assertThat(qualifier.resolvesToStaticField(name)).isFalse())
+            .doesNotThrowAnyException();
+    }
+
     private static MethodDeclaration parseMethod(String source) {
         return StaticJavaParser.parse(source).findFirst(MethodDeclaration.class).orElseThrow();
+    }
+
+    private static final class StackOverflowNameExpr extends NameExpr {
+
+        private StackOverflowNameExpr(String name) {
+            super(name);
+        }
+
+        @Override
+        public ResolvedValueDeclaration resolve() {
+            throw new StackOverflowError("simulated JavaParser recursion");
+        }
     }
 }

--- a/src/test/java/de/burger/forensics/adaptersupport/javaparser/scanner/JavaParserScanEventCollectorTest.java
+++ b/src/test/java/de/burger/forensics/adaptersupport/javaparser/scanner/JavaParserScanEventCollectorTest.java
@@ -1,7 +1,12 @@
 package de.burger.forensics.adaptersupport.javaparser.scanner;
 
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.stmt.SwitchEntry;
+import de.burger.forensics.adaptersupport.javaparser.ConditionRenderingStrategy;
 import de.burger.forensics.adaptersupport.javaparser.DefaultConditionRenderingStrategy;
 import de.burger.forensics.adaptersupport.javaparser.InstanceFieldNormalizer;
+import de.burger.forensics.adaptersupport.javaparser.MethodScanContext;
 import de.burger.forensics.adaptersupport.javaparser.MethodEventExtractor;
 import de.burger.forensics.domain.model.RuleTemplate;
 import de.burger.forensics.domain.model.ScanEvent;
@@ -54,5 +59,45 @@ class JavaParserScanEventCollectorTest {
         assertThat(JavaParserScanEventCollector.collectSafely(parserFactory.create(tempDir), broken, extractor)).isEmpty();
         assertThat(JavaParserScanEventCollector.collectSafely(null, broken, extractor)).isEmpty();
         assertThat(JavaParserScanEventCollector.collectSafely(parserFactory.create(tempDir), broken, null)).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyWhenCollectionHitsStackOverflow(@TempDir Path tempDir) throws IOException {
+        Path source = tempDir.resolve("Recursive.java");
+        Files.writeString(source, """
+            package example;
+            class Recursive {
+                void run(int value) {
+                    if (value > 0) {
+                        System.out.println(value);
+                    }
+                }
+            }
+            """);
+        MethodEventExtractor throwingExtractor = new MethodEventExtractor(new StackOverflowRenderingStrategy());
+
+        assertThat(JavaParserScanEventCollector.collectSafely(
+            parserFactory.create(tempDir),
+            source,
+            throwingExtractor
+        )).isEmpty();
+    }
+
+    private static final class StackOverflowRenderingStrategy implements ConditionRenderingStrategy {
+
+        @Override
+        public String renderCondition(Expression condition, MethodScanContext context) {
+            throw new StackOverflowError("simulated JavaParser recursion");
+        }
+
+        @Override
+        public String renderReturn(ReturnStmt returnStmt, MethodScanContext context) {
+            throw new StackOverflowError("simulated JavaParser recursion");
+        }
+
+        @Override
+        public String renderSwitchLabel(SwitchEntry entry, MethodScanContext context) {
+            throw new StackOverflowError("simulated JavaParser recursion");
+        }
     }
 }


### PR DESCRIPTION
What:
- Added JavaParserResolutionGuard for optional symbol-resolution calls in adapter support.
- Routed NameExpr, MethodCallExpr, and FieldAccessExpr resolution through the guard.
- Added a scanner-level StackOverflowError safety net for per-file collection.
- Added regression tests for direct resolver StackOverflowError, recursive type scans, collector fallback, and enum field classification.

Why:
- Large source graphs such as WildFly can make JavaParser's symbol solver recurse until StackOverflowError.
- Symbol resolution is optional enrichment and must not terminate BTM rule generation.

Changes:
- InstanceFieldNormalizer and StaticFieldQualifier now run AST-local field heuristics before symbol resolution.
- DefaultTypeReferenceQualifier keeps unresolved or solver-failing enrichment empty instead of throwing.
- JavaParserScanEventCollector skips only the failing file when parsing or symbol resolution overflows.

Impact:
- Fixes a scanner crash without catching Throwable broadly.
- Preserves existing instance and static field qualification behavior.
- No public API, Gradle task, dependency, or architecture changes.

Testing:
- .\\gradlew.bat test --tests de.burger.forensics.adaptersupport.javaparser.JavaParserResolutionGuardTest --tests de.burger.forensics.adaptersupport.javaparser.InstanceFieldNormalizerTest --tests de.burger.forensics.adaptersupport.javaparser.StaticFieldQualifierTest --tests de.burger.forensics.adaptersupport.javaparser.DefaultConditionRenderingStrategyTest --tests de.burger.forensics.adapters.javaparser.JavaParserScannerTest --tests de.burger.forensics.adaptersupport.javaparser.scanner.JavaParserScanEventCollectorTest --dependency-verification strict --console=plain --stacktrace
- .\\gradlew.bat test --dependency-verification strict --no-daemon --console=plain --stacktrace
- .\\gradlew.bat clean test jacocoTestReport jacocoTestCoverageVerification checkPackageCoverage --dependency-verification strict --no-daemon --console=plain --stacktrace
- .\\gradlew.bat publishToMavenLocal --dependency-verification strict --no-daemon --console=plain --stacktrace
- D:\\Projects\\wildfly .\\mvnw.cmd -N generate-test-resources -Dforensics -Dforensics.sourceRoot=<wildfly-root> -Dforensics.excludePackages=org.jboss.as.test,org.wildfly.test -DskipTests