### PR TITLE
fix: resolve SonarCloud leak issues

### DIFF
--- a/src/main/java/de/burger/forensics/adapters/persistence/h2/H2AnalysisStoreAdapter.java
+++ b/src/main/java/de/burger/forensics/adapters/persistence/h2/H2AnalysisStoreAdapter.java
@@ -38,6 +38,122 @@ import java.util.Objects;
  */
 public final class H2AnalysisStoreAdapter implements AnalysisStorePort, SemanticAnalysisStorePort {
 
+    private static final String ANALYSIS_RUN_ID_REQUIRED = "Analysis run id must not be null.";
+    private static final String INSERT_ANALYSIS_RUN_SQL = """
+            INSERT INTO analysis_run (
+                analysis_run_id,
+                project_key,
+                build_id,
+                source_fingerprint,
+                classpath_fingerprint,
+                btm_rules_fingerprint,
+                artifact_fingerprint,
+                plugin_version,
+                schema_version,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """;
+    private static final String UPDATE_ANALYSIS_RUN_STATUS_SQL = """
+            UPDATE analysis_run
+            SET status = ?
+            WHERE analysis_run_id = ?
+            """;
+    private static final String INSERT_SOURCE_FILE_SQL = """
+            INSERT INTO source_file (
+                analysis_run_id,
+                relative_path,
+                absolute_path,
+                sha256,
+                file_size,
+                last_modified_epoch_millis
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """;
+    private static final String INSERT_SCAN_METHOD_SQL = """
+            INSERT INTO scan_method (
+                analysis_run_id,
+                method_key,
+                fqcn,
+                method_name,
+                signature,
+                return_type
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """;
+    private static final String INSERT_SCAN_EVENT_SQL = """
+            INSERT INTO scan_event (
+                analysis_run_id,
+                fqcn,
+                method_name,
+                signature,
+                rule_template,
+                line_number,
+                condition_text,
+                language,
+                return_type
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """;
+    private static final String INSERT_BTM_RULE_SQL = """
+            INSERT INTO btm_rule (
+                analysis_run_id,
+                rule_id,
+                fqcn,
+                method_name,
+                rule_template,
+                line_number,
+                rendered_rule,
+                emitted_to_btm
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """;
+    private static final String INSERT_ARTIFACT_CHECKSUM_SQL = """
+            INSERT INTO artifact_checksum (
+                analysis_run_id,
+                artifact_path,
+                artifact_type,
+                sha256,
+                size_bytes
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """;
+    private static final String INSERT_JOERN_IMPORT_RUN_SQL = """
+            INSERT INTO joern_import_run (
+                analysis_run_id,
+                joern_fingerprint,
+                joern_version,
+                status,
+                started_at
+            )
+            VALUES (?, ?, ?, ?, ?)
+            """;
+    private static final String INSERT_SEMANTIC_ANCHOR_SQL = """
+            INSERT INTO semantic_anchor (
+                analysis_run_id,
+                scan_event_key,
+                semantic_node_id,
+                relative_path,
+                fqcn,
+                method_name,
+                signature,
+                line_number,
+                normalized_code,
+                confidence,
+                match_strategy
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """;
+    private static final String UPDATE_JOERN_IMPORT_RUN_STATUS_SQL = """
+            UPDATE joern_import_run
+            SET status = ?,
+                completed_at = ?
+            WHERE analysis_run_id = ?
+              AND joern_fingerprint = ?
+            """;
+
     private final Path databasePath;
     private final SqlTransactionRunner transactions;
 
@@ -56,23 +172,7 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
         Objects.requireNonNull(identity, "Build identity must not be null.");
         transactions.run("create analysis run", connection -> {
             deleteExistingRun(connection, identity.analysisRunId());
-            try (PreparedStatement statement = connection.prepareStatement("""
-                    INSERT INTO analysis_run (
-                        analysis_run_id,
-                        project_key,
-                        build_id,
-                        source_fingerprint,
-                        classpath_fingerprint,
-                        btm_rules_fingerprint,
-                        artifact_fingerprint,
-                        plugin_version,
-                        schema_version,
-                        status,
-                        created_at,
-                        updated_at
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """)) {
+            try (PreparedStatement statement = connection.prepareStatement(INSERT_ANALYSIS_RUN_SQL)) {
                 statement.setString(1, identity.analysisRunId().value());
                 statement.setString(2, identity.projectKey());
                 statement.setString(3, identity.buildId().value());
@@ -93,14 +193,10 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
 
     @Override
     public void updateAnalysisRunStatus(AnalysisRunId analysisRunId, AnalysisRunStatus status) {
-        Objects.requireNonNull(analysisRunId, "Analysis run id must not be null.");
+        Objects.requireNonNull(analysisRunId, ANALYSIS_RUN_ID_REQUIRED);
         Objects.requireNonNull(status, "Analysis run status must not be null.");
         transactions.run("update analysis run status", connection -> {
-            try (PreparedStatement statement = connection.prepareStatement("""
-                    UPDATE analysis_run
-                    SET status = ?
-                    WHERE analysis_run_id = ?
-                    """)) {
+            try (PreparedStatement statement = connection.prepareStatement(UPDATE_ANALYSIS_RUN_STATUS_SQL)) {
                 statement.setString(1, status.name());
                 statement.setString(2, analysisRunId.value());
                 statement.executeUpdate();
@@ -110,20 +206,10 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
 
     @Override
     public void storeSourceFiles(AnalysisRunId analysisRunId, List<SourceFileSnapshot> sourceFiles) {
-        Objects.requireNonNull(analysisRunId, "Analysis run id must not be null.");
+        Objects.requireNonNull(analysisRunId, ANALYSIS_RUN_ID_REQUIRED);
         Objects.requireNonNull(sourceFiles, "Source files must not be null.");
         transactions.run("store source files", connection -> {
-            try (PreparedStatement statement = connection.prepareStatement("""
-                    INSERT INTO source_file (
-                        analysis_run_id,
-                        relative_path,
-                        absolute_path,
-                        sha256,
-                        file_size,
-                        last_modified_epoch_millis
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?)
-                    """)) {
+            try (PreparedStatement statement = connection.prepareStatement(INSERT_SOURCE_FILE_SQL)) {
                 for (SourceFileSnapshot sourceFile : sourceFiles) {
                     statement.setString(1, analysisRunId.value());
                     statement.setString(2, sourceFile.relativePath());
@@ -140,20 +226,10 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
 
     @Override
     public void storeMethods(AnalysisRunId analysisRunId, List<MethodEntry> methods) {
-        Objects.requireNonNull(analysisRunId, "Analysis run id must not be null.");
+        Objects.requireNonNull(analysisRunId, ANALYSIS_RUN_ID_REQUIRED);
         Objects.requireNonNull(methods, "Methods must not be null.");
         transactions.run("store methods", connection -> {
-            try (PreparedStatement statement = connection.prepareStatement("""
-                    INSERT INTO scan_method (
-                        analysis_run_id,
-                        method_key,
-                        fqcn,
-                        method_name,
-                        signature,
-                        return_type
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?)
-                    """)) {
+            try (PreparedStatement statement = connection.prepareStatement(INSERT_SCAN_METHOD_SQL)) {
                 for (MethodEntry method : methods) {
                     statement.setString(1, analysisRunId.value());
                     statement.setString(2, method.fullyQualifiedMethodName());
@@ -170,23 +246,10 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
 
     @Override
     public void storeScanEvents(AnalysisRunId analysisRunId, List<ScanEvent> events) {
-        Objects.requireNonNull(analysisRunId, "Analysis run id must not be null.");
+        Objects.requireNonNull(analysisRunId, ANALYSIS_RUN_ID_REQUIRED);
         Objects.requireNonNull(events, "Scan events must not be null.");
         transactions.run("store scan events", connection -> {
-            try (PreparedStatement statement = connection.prepareStatement("""
-                    INSERT INTO scan_event (
-                        analysis_run_id,
-                        fqcn,
-                        method_name,
-                        signature,
-                        rule_template,
-                        line_number,
-                        condition_text,
-                        language,
-                        return_type
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """)) {
+            try (PreparedStatement statement = connection.prepareStatement(INSERT_SCAN_EVENT_SQL)) {
                 for (ScanEvent event : events) {
                     SourceLocation location = event.location();
                     statement.setString(1, analysisRunId.value());
@@ -207,23 +270,11 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
 
     @Override
     public void storeRules(AnalysisRunId analysisRunId, List<Rule> rules, Map<String, String> renderedRulesByRuleId) {
-        Objects.requireNonNull(analysisRunId, "Analysis run id must not be null.");
+        Objects.requireNonNull(analysisRunId, ANALYSIS_RUN_ID_REQUIRED);
         Objects.requireNonNull(rules, "Rules must not be null.");
         Objects.requireNonNull(renderedRulesByRuleId, "Rendered rules must not be null.");
         transactions.run("store rules", connection -> {
-            try (PreparedStatement statement = connection.prepareStatement("""
-                    INSERT INTO btm_rule (
-                        analysis_run_id,
-                        rule_id,
-                        fqcn,
-                        method_name,
-                        rule_template,
-                        line_number,
-                        rendered_rule,
-                        emitted_to_btm
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                    """)) {
+            try (PreparedStatement statement = connection.prepareStatement(INSERT_BTM_RULE_SQL)) {
                 for (Rule rule : rules) {
                     SourceLocation location = rule.location();
                     String renderedRule = renderedRulesByRuleId.get(rule.id().value());
@@ -244,19 +295,10 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
 
     @Override
     public void storeArtifactChecksums(AnalysisRunId analysisRunId, List<ArtifactChecksum> checksums) {
-        Objects.requireNonNull(analysisRunId, "Analysis run id must not be null.");
+        Objects.requireNonNull(analysisRunId, ANALYSIS_RUN_ID_REQUIRED);
         Objects.requireNonNull(checksums, "Artifact checksums must not be null.");
         transactions.run("store artifact checksums", connection -> {
-            try (PreparedStatement statement = connection.prepareStatement("""
-                    INSERT INTO artifact_checksum (
-                        analysis_run_id,
-                        artifact_path,
-                        artifact_type,
-                        sha256,
-                        size_bytes
-                    )
-                    VALUES (?, ?, ?, ?, ?)
-                    """)) {
+            try (PreparedStatement statement = connection.prepareStatement(INSERT_ARTIFACT_CHECKSUM_SQL)) {
                 for (ArtifactChecksum checksum : checksums) {
                     statement.setString(1, analysisRunId.value());
                     statement.setString(2, checksum.path());
@@ -272,20 +314,11 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
 
     @Override
     public void createSemanticImportRun(AnalysisRunId analysisRunId, SemanticAnalysisResult result) {
-        Objects.requireNonNull(analysisRunId, "Analysis run id must not be null.");
+        Objects.requireNonNull(analysisRunId, ANALYSIS_RUN_ID_REQUIRED);
         Objects.requireNonNull(result, "Semantic analysis result must not be null.");
         transactions.run("create semantic import run", connection -> {
             deleteSemanticData(connection, analysisRunId);
-            try (PreparedStatement statement = connection.prepareStatement("""
-                    INSERT INTO joern_import_run (
-                        analysis_run_id,
-                        joern_fingerprint,
-                        joern_version,
-                        status,
-                        started_at
-                    )
-                    VALUES (?, ?, ?, ?, ?)
-                    """)) {
+            try (PreparedStatement statement = connection.prepareStatement(INSERT_JOERN_IMPORT_RUN_SQL)) {
                 statement.setString(1, analysisRunId.value());
                 statement.setString(2, result.semanticFingerprint());
                 statement.setString(3, result.providerVersion());
@@ -298,7 +331,7 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
 
     @Override
     public void storeSemanticGraph(AnalysisRunId analysisRunId, SemanticAnalysisResult result) {
-        Objects.requireNonNull(analysisRunId, "Analysis run id must not be null.");
+        Objects.requireNonNull(analysisRunId, ANALYSIS_RUN_ID_REQUIRED);
         Objects.requireNonNull(result, "Semantic analysis result must not be null.");
         transactions.run("store semantic graph", connection -> {
             insertSemanticNodes(connection, analysisRunId, result.nodes());
@@ -312,25 +345,10 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
 
     @Override
     public void storeSemanticAnchors(AnalysisRunId analysisRunId, List<SemanticAnchor> anchors) {
-        Objects.requireNonNull(analysisRunId, "Analysis run id must not be null.");
+        Objects.requireNonNull(analysisRunId, ANALYSIS_RUN_ID_REQUIRED);
         Objects.requireNonNull(anchors, "Semantic anchors must not be null.");
         transactions.run("store semantic anchors", connection -> {
-            try (PreparedStatement statement = connection.prepareStatement("""
-                    INSERT INTO semantic_anchor (
-                        analysis_run_id,
-                        scan_event_key,
-                        semantic_node_id,
-                        relative_path,
-                        fqcn,
-                        method_name,
-                        signature,
-                        line_number,
-                        normalized_code,
-                        confidence,
-                        match_strategy
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """)) {
+            try (PreparedStatement statement = connection.prepareStatement(INSERT_SEMANTIC_ANCHOR_SQL)) {
                 for (SemanticAnchor anchor : anchors) {
                     statement.setString(1, analysisRunId.value());
                     statement.setString(2, anchor.scanEventKey());
@@ -356,7 +374,7 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
             String semanticFingerprint,
             String status
     ) {
-        Objects.requireNonNull(analysisRunId, "Analysis run id must not be null.");
+        Objects.requireNonNull(analysisRunId, ANALYSIS_RUN_ID_REQUIRED);
         if (semanticFingerprint == null || semanticFingerprint.isBlank()) {
             throw new IllegalArgumentException("Semantic fingerprint must not be blank.");
         }
@@ -364,13 +382,7 @@ public final class H2AnalysisStoreAdapter implements AnalysisStorePort, Semantic
             throw new IllegalArgumentException("Semantic import status must not be blank.");
         }
         transactions.run("update semantic import status", connection -> {
-            try (PreparedStatement statement = connection.prepareStatement("""
-                    UPDATE joern_import_run
-                    SET status = ?,
-                        completed_at = ?
-                    WHERE analysis_run_id = ?
-                      AND joern_fingerprint = ?
-                    """)) {
+            try (PreparedStatement statement = connection.prepareStatement(UPDATE_JOERN_IMPORT_RUN_STATUS_SQL)) {
                 statement.setString(1, status);
                 statement.setTimestamp(2, new Timestamp(System.currentTimeMillis()));
                 statement.setString(3, analysisRunId.value());

--- a/src/main/java/de/burger/forensics/adaptersupport/persistence/h2/SqlTransactionRunner.java
+++ b/src/main/java/de/burger/forensics/adaptersupport/persistence/h2/SqlTransactionRunner.java
@@ -16,16 +16,20 @@ public final class SqlTransactionRunner {
 
     public void run(String operation, SqlWork work) {
         try (Connection connection = connectionFactory.openConnection()) {
-            connection.setAutoCommit(false);
-            try {
-                work.execute(connection);
-                connection.commit();
-            } catch (SQLException | RuntimeException e) {
-                rollback(connection, e);
-                throw e;
-            }
+            executeInTransaction(connection, work);
         } catch (SQLException e) {
             throw new IllegalStateException("Failed to " + operation + " H2 analysis store.", e);
+        }
+    }
+
+    private static void executeInTransaction(Connection connection, SqlWork work) throws SQLException {
+        connection.setAutoCommit(false);
+        try {
+            work.execute(connection);
+            connection.commit();
+        } catch (SQLException | RuntimeException e) {
+            rollback(connection, e);
+            throw e;
         }
     }
 

--- a/src/main/java/de/burger/forensics/domain/model/analysis/AnalysisStoreCleanupPolicy.java
+++ b/src/main/java/de/burger/forensics/domain/model/analysis/AnalysisStoreCleanupPolicy.java
@@ -6,12 +6,20 @@ import java.util.Arrays;
  * Controls whether analysis store files are retained after task execution.
  */
 public enum AnalysisStoreCleanupPolicy {
-    DELETE_ON_SUCCESS,
-    KEEP_ON_SUCCESS,
-    KEEP_ON_FAILURE,
-    KEEP_ALWAYS;
+    DELETE_ON_SUCCESS(true, false),
+    KEEP_ON_SUCCESS(false, false),
+    KEEP_ON_FAILURE(true, false),
+    KEEP_ALWAYS(false, false);
 
     public static final AnalysisStoreCleanupPolicy DEFAULT = KEEP_ON_SUCCESS;
+
+    private final boolean deleteAfterSuccess;
+    private final boolean deleteAfterFailure;
+
+    AnalysisStoreCleanupPolicy(boolean deleteAfterSuccess, boolean deleteAfterFailure) {
+        this.deleteAfterSuccess = deleteAfterSuccess;
+        this.deleteAfterFailure = deleteAfterFailure;
+    }
 
     public static AnalysisStoreCleanupPolicy from(String value) {
         if (value == null || value.isBlank()) {
@@ -24,10 +32,10 @@ public enum AnalysisStoreCleanupPolicy {
     }
 
     public boolean shouldDeleteAfterSuccess() {
-        return this == DELETE_ON_SUCCESS || this == KEEP_ON_FAILURE;
+        return deleteAfterSuccess;
     }
 
     public boolean shouldDeleteAfterFailure() {
-        return false;
+        return deleteAfterFailure;
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/common/BtmGenerationDefaults.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/common/BtmGenerationDefaults.java
@@ -31,7 +31,8 @@ public final class BtmGenerationDefaults {
 
     private static final Path FORENSICS_DIRECTORY = Path.of("forensics");
     private static final Path CACHE_DIRECTORY = FORENSICS_DIRECTORY.resolve("cache");
-    private static final Path ANALYSIS_STORE_DIRECTORY = FORENSICS_DIRECTORY.resolve("analysis-store");
+    private static final Path ANALYSIS_STORE_DIRECTORY =
+            FORENSICS_DIRECTORY.resolve(DEFAULT_ANALYSIS_STORE_DATABASE_FILE_NAME);
 
     private BtmGenerationDefaults() {
     }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/common/BtmGenerationRunner.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/common/BtmGenerationRunner.java
@@ -25,7 +25,6 @@ import de.burger.forensics.domain.model.analysis.BuildId;
 import de.burger.forensics.domain.model.analysis.BuildIdentity;
 import de.burger.forensics.domain.model.cache.ScanPhase;
 import de.burger.forensics.domain.model.cache.ScanProfile;
-import de.burger.forensics.domain.model.entry.MethodEntry;
 import de.burger.forensics.domain.port.out.CodeScanPort;
 import de.burger.forensics.domain.port.out.LogPort;
 import de.burger.forensics.domain.port.out.RuleRenderPort;
@@ -219,7 +218,33 @@ public final class BtmGenerationRunner {
         ArtifactChecksumService checksumService = new ArtifactChecksumService();
         ArtifactChecksum btmChecksum = null;
         boolean success = false;
-        H2AnalysisStoreAdapter store = new H2AnalysisStoreAdapter(databaseFile);
+        try (H2AnalysisStoreAdapter store = new H2AnalysisStoreAdapter(databaseFile)) {
+            btmChecksum = persistAnalysisRun(
+                    request,
+                    output,
+                    sourceFingerprint,
+                    dedupedRules,
+                    identity,
+                    profileCollector,
+                    checksumService,
+                    store);
+            success = true;
+        } finally {
+            if (success && btmChecksum != null) {
+                writeAnalysisArtifacts(request, identity, btmChecksum, checksumService);
+            }
+            applyCleanupPolicy(request, success);
+        }
+    }
+
+    private ArtifactChecksum persistAnalysisRun(BtmGenerationRequest request,
+                                                RunOutput output,
+                                                SourceFingerprintResult sourceFingerprint,
+                                                List<String> dedupedRules,
+                                                BuildIdentity identity,
+                                                ScanProfileCollector profileCollector,
+                                                ArtifactChecksumService checksumService,
+                                                H2AnalysisStoreAdapter store) {
         try {
             store.initializeSchema();
             store.createAnalysisRun(identity);
@@ -227,25 +252,25 @@ public final class BtmGenerationRunner {
             store.storeSourceFiles(identity.analysisRunId(), sourceFingerprint.sourceFiles());
             store.storeMethods(identity.analysisRunId(), output.context().getMethodEntries());
             store.storeScanEvents(identity.analysisRunId(), output.context().getEvents());
-            store.storeRules(identity.analysisRunId(), output.domainRules(), renderedRulesByRuleId(output.domainRules(), output.renderedRules()));
+            store.storeRules(
+                    identity.analysisRunId(),
+                    output.domainRules(),
+                    renderedRulesByRuleId(output.domainRules(), output.renderedRules()));
             profileCollector.measure(ScanPhase.BTM_FILE_WRITING, () -> {
                 writeRules(request, dedupedRules, identity);
                 return null;
             });
             store.updateAnalysisRunStatus(identity.analysisRunId(), AnalysisRunStatus.BTM_GENERATED);
-            btmChecksum = checksumService.checksumFile(analysisBaseDirectory(request), request.outputFile(), "byteman-rules");
+            ArtifactChecksum btmChecksum = checksumService.checksumFile(
+                    analysisBaseDirectory(request),
+                    request.outputFile(),
+                    "byteman-rules");
             store.storeArtifactChecksums(identity.analysisRunId(), List.of(btmChecksum));
             store.updateAnalysisRunStatus(identity.analysisRunId(), AnalysisRunStatus.COMPLETED);
-            success = true;
+            return btmChecksum;
         } catch (RuntimeException exception) {
             markFailed(store, identity.analysisRunId());
             throw exception;
-        } finally {
-            store.close();
-            if (success && btmChecksum != null) {
-                writeAnalysisArtifacts(request, identity, btmChecksum, checksumService);
-            }
-            applyCleanupPolicy(request, success);
         }
     }
 

--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTask.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/GenerateBtmTask.java
@@ -1,5 +1,6 @@
 package de.burger.forensics.plugin.btmgen.gradle;
 
+import de.burger.forensics.domain.model.analysis.BuildIdentity;
 import de.burger.forensics.plugin.btmgen.common.BtmGenerationException;
 import de.burger.forensics.plugin.btmgen.common.BtmGenerationRequest;
 import de.burger.forensics.plugin.btmgen.common.BtmGenerationRunner;
@@ -189,8 +190,8 @@ public abstract class GenerateBtmTask extends DefaultTask {
                 .minBranchesPerMethod(minBranches())
                 .includeTimestampHeader(getIncludeTimestampHeader().getOrElse(false))
                 .cleanupPolicy(getCleanupPolicy().getOrElse("KEEP_ON_SUCCESS"))
-                .projectKey(getProjectKey().getOrElse("UNKNOWN"))
-                .pluginVersion(getPluginVersion().getOrElse("UNKNOWN"))
+                .projectKey(getProjectKey().getOrElse(BuildIdentity.UNKNOWN))
+                .pluginVersion(getPluginVersion().getOrElse(BuildIdentity.UNKNOWN))
                 .manifestFile(getManifestFile().get().getAsFile().toPath())
                 .checksumsFile(getChecksumsFile().get().getAsFile().toPath());
 
@@ -230,8 +231,8 @@ public abstract class GenerateBtmTask extends DefaultTask {
         conventionIfMissing(getAnalysisStoreEnabled(), true);
         conventionIfMissing(getAnalysisStoreDirectory(), layout.getBuildDirectory().dir("forensics/analysis-store"));
         conventionIfMissing(getCleanupPolicy(), "KEEP_ON_SUCCESS");
-        conventionIfMissing(getProjectKey(), "UNKNOWN");
-        conventionIfMissing(getPluginVersion(), "UNKNOWN");
+        conventionIfMissing(getProjectKey(), BuildIdentity.UNKNOWN);
+        conventionIfMissing(getPluginVersion(), BuildIdentity.UNKNOWN);
         conventionIfMissing(getManifestFile(), layout.getBuildDirectory().file("forensics/manifest.json"));
         conventionIfMissing(getChecksumsFile(), layout.getBuildDirectory().file("forensics/checksums.sha256"));
         conventionIfMissing(getProfilingEnabled(), false);

--- a/src/test/java/de/burger/forensics/adapters/filesystem/AnalysisManifestWriterTest.java
+++ b/src/test/java/de/burger/forensics/adapters/filesystem/AnalysisManifestWriterTest.java
@@ -44,11 +44,12 @@ class AnalysisManifestWriterTest {
                 new ArtifactChecksum("forensics.btm", "byteman-rules", "abc", 12L)));
 
         String json = Files.readString(manifest);
-        assertThat(json).contains("\"schemaVersion\": \"1\"");
-        assertThat(json).contains("\"projectKey\": \"demo\\\"project\\\\with\\b\\f\\n\\r\\tcontrols\"");
-        assertThat(json).contains("\"analysisRunId\": \"run-1\"");
-        assertThat(json).contains("\"joernEnabled\": false");
-        assertThat(json).contains("\"path\": \"forensics.btm\"");
+        assertThat(json).contains(
+                "\"schemaVersion\": \"1\"",
+                "\"projectKey\": \"demo\\\"project\\\\with\\b\\f\\n\\r\\tcontrols\"",
+                "\"analysisRunId\": \"run-1\"",
+                "\"joernEnabled\": false",
+                "\"path\": \"forensics.btm\"");
     }
 
     @Test


### PR DESCRIPTION
What:
- Move H2 analysis-store SQL text blocks out of transaction lambdas.
- Reuse existing constants for analysis store and unknown build identity defaults.
- Refactor H2 transaction execution and analysis-store persistence to reduce nested try handling and use try-with-resources.
- Keep cleanup policy behavior explicit through enum state instead of a constant-return method.
- Collapse repeated manifest assertions into one AssertJ chain.

Why:
- SonarCloud reported maintainability issues in the leak period for duplicated literals, nested try blocks, resource handling, and assertion style.

Changes:
- Adapter support: extract SQL transaction body into executeInTransaction.
- Domain: store cleanup policy decisions as enum fields while preserving existing methods.
- Plugin common/Gradle: remove unused import, use try-with-resources for H2AnalysisStoreAdapter, and reuse BuildIdentity.UNKNOWN/default analysis-store constants.
- Tests: adjust AnalysisManifestWriterTest assertion style.

Impact:
- No generated output format, Byteman rendering, runtime tracing, or cleanup behavior changes are intended.
- No dependencies, build baselines, or coverage thresholds were changed.

Testing:
- .\gradlew.bat compileJava --dependency-verification strict --console=plain --stacktrace
- .\gradlew.bat test --tests de.burger.forensics.adapters.persistence.h2.H2AnalysisStoreAdapterTest --tests de.burger.forensics.adapters.persistence.h2.H2ScanCacheAdapterTest --tests de.burger.forensics.adapters.persistence.h2.H2SchemaInitializerTest --tests de.burger.forensics.domain.model.analysis.AnalysisStoreCleanupPolicyTest --tests de.burger.forensics.adapters.filesystem.AnalysisManifestWriterTest --dependency-verification strict --console=plain --stacktrace
- .\gradlew.bat test --dependency-verification strict --console=plain --stacktrace
- .\gradlew.bat clean test jacocoTestReport jacocoTestCoverageVerification checkPackageCoverage --dependency-verification strict --console=plain --stacktrace
- .\gradlew.bat validatePlugins --dependency-verification strict --no-daemon --console=plain --stacktrace