### PR TITLE
fix: handle Joern command timeout output safely

### DIFF
--- a/src/main/java/de/burger/forensics/adaptersupport/joern/ProcessJoernCommandExecutor.java
+++ b/src/main/java/de/burger/forensics/adaptersupport/joern/ProcessJoernCommandExecutor.java
@@ -28,7 +28,8 @@ public final class ProcessJoernCommandExecutor implements JoernCommandExecutor {
             boolean completed = process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS);
             if (!completed) {
                 process.destroyForcibly();
-                return new JoernCommandResult(-1, read(process.getInputStream()), "Command timed out.");
+                process.waitFor();
+                return new JoernCommandResult(-1, "", "Command timed out.");
             }
             return new JoernCommandResult(
                     process.exitValue(),


### PR DESCRIPTION
## Summary
- avoid reading process stdout after forced Joern command timeout
- wait for the forcibly terminated process before returning the timeout result
- unblock the Linux CI path that prevented the SonarCloud scan from running

## Verification
- `wsl.exe bash -lc "cd /mnt/d/Projects/forensics_tracing && ./gradlew test --tests de.burger.forensics.adaptersupport.joern.JoernOutputParserTest.processExecutorReportsTimeouts --console=plain --stacktrace"`
- `wsl.exe bash -lc "cd /mnt/d/Projects/forensics_tracing && ./gradlew clean test jacocoTestReport jacocoTestCoverageVerification checkPackageCoverage --console=plain --stacktrace"`
- `./gradlew.bat test --tests de.burger.forensics.adaptersupport.joern.JoernOutputParserTest.processExecutorReportsTimeouts --console=plain --stacktrace`