### PR TITLE
fix: resolve SonarCloud open issues

### DIFF
--- a/src/main/java/de/burger/forensics/adaptersupport/joern/JoernOutputParser.java
+++ b/src/main/java/de/burger/forensics/adaptersupport/joern/JoernOutputParser.java
@@ -23,6 +23,10 @@ import java.util.Objects;
  */
 public final class JoernOutputParser {
 
+    private static final String FIELD_SIGNATURE = "signature";
+    private static final String FIELD_SOURCE = "source";
+    private static final String FIELD_TARGET = "target";
+
     public SemanticAnalysisResult parse(
             JoernArtifactPaths paths,
             List<ArtifactChecksum> artifacts,
@@ -54,7 +58,7 @@ public final class JoernOutputParser {
                 JsonField.text(object, "file"),
                 JsonField.optionalText(object, "fqcn"),
                 JsonField.text(object, "method"),
-                JsonField.optionalText(object, "signature"),
+                JsonField.optionalText(object, FIELD_SIGNATURE),
                 JsonField.integer(object, "line"),
                 JsonField.optionalText(object, "code"));
     }
@@ -62,8 +66,8 @@ public final class JoernOutputParser {
     private SemanticEdge edge(String object) {
         return new SemanticEdge(
                 JsonField.text(object, "id"),
-                JsonField.text(object, "source"),
-                JsonField.text(object, "target"),
+                JsonField.text(object, FIELD_SOURCE),
+                JsonField.text(object, FIELD_TARGET),
                 JsonField.text(object, "type"));
     }
 
@@ -73,7 +77,7 @@ public final class JoernOutputParser {
                 JsonField.text(object, "file"),
                 JsonField.text(object, "fqcn"),
                 JsonField.text(object, "name"),
-                JsonField.optionalText(object, "signature"),
+                JsonField.optionalText(object, FIELD_SIGNATURE),
                 JsonField.integer(object, "line"));
     }
 
@@ -86,16 +90,16 @@ public final class JoernOutputParser {
 
     private ControlFlowRelation controlFlow(String object) {
         return new ControlFlowRelation(
-                JsonField.text(object, "source"),
-                JsonField.text(object, "target"),
+                JsonField.text(object, FIELD_SOURCE),
+                JsonField.text(object, FIELD_TARGET),
                 JsonField.text(object, "type"));
     }
 
     private DataFlowPath dataFlowPath(String object) {
         return new DataFlowPath(
                 JsonField.text(object, "id"),
-                JsonField.text(object, "source"),
-                JsonField.text(object, "target"),
+                JsonField.text(object, FIELD_SOURCE),
+                JsonField.text(object, FIELD_TARGET),
                 JsonArray.objects(object, "steps").stream()
                         .map(step -> new DataFlowStep(
                                 JsonField.text(step, "node"),
@@ -111,7 +115,7 @@ public final class JoernOutputParser {
                 JsonField.text(object, "file"),
                 JsonField.optionalText(object, "fqcn"),
                 JsonField.text(object, "method"),
-                JsonField.optionalText(object, "signature"),
+                JsonField.optionalText(object, FIELD_SIGNATURE),
                 JsonField.integer(object, "line"),
                 JsonField.optionalText(object, "code"),
                 JsonField.decimal(object, "confidence"),
@@ -150,17 +154,15 @@ public final class JoernOutputParser {
         private static List<String> splitObjects(String arrayBody) {
             java.util.ArrayList<String> objects = new java.util.ArrayList<>();
             int cursor = 0;
-            while (cursor < arrayBody.length()) {
-                int openBrace = arrayBody.indexOf('{', cursor);
-                if (openBrace < 0) {
-                    break;
-                }
+            int openBrace = arrayBody.indexOf('{', cursor);
+            while (openBrace >= 0) {
                 int closeBrace = matching(arrayBody, openBrace, '{', '}');
                 if (closeBrace < 0) {
-                    break;
+                    return List.copyOf(objects);
                 }
                 objects.add(arrayBody.substring(openBrace, closeBrace + 1));
                 cursor = closeBrace + 1;
+                openBrace = arrayBody.indexOf('{', cursor);
             }
             return List.copyOf(objects);
         }
@@ -225,16 +227,13 @@ public final class JoernOutputParser {
                 if (escaped) {
                     builder.append(unescape(current));
                     escaped = false;
-                    continue;
-                }
-                if (current == '\\') {
+                } else if (current == '\\') {
                     escaped = true;
-                    continue;
-                }
-                if (current == '"') {
+                } else if (current == '"') {
                     return builder.toString();
+                } else {
+                    builder.append(current);
                 }
-                builder.append(current);
             }
             return null;
         }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/common/BtmGenerationRunner.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/common/BtmGenerationRunner.java
@@ -220,13 +220,14 @@ public final class BtmGenerationRunner {
         boolean success = false;
         try (H2AnalysisStoreAdapter store = new H2AnalysisStoreAdapter(databaseFile)) {
             btmChecksum = persistAnalysisRun(
-                    request,
-                    output,
-                    sourceFingerprint,
-                    dedupedRules,
-                    identity,
-                    profileCollector,
-                    checksumService,
+                    new AnalysisPersistence(
+                            request,
+                            output,
+                            sourceFingerprint,
+                            dedupedRules,
+                            identity,
+                            profileCollector,
+                            checksumService),
                     store);
             success = true;
         } finally {
@@ -237,39 +238,32 @@ public final class BtmGenerationRunner {
         }
     }
 
-    private ArtifactChecksum persistAnalysisRun(BtmGenerationRequest request,
-                                                RunOutput output,
-                                                SourceFingerprintResult sourceFingerprint,
-                                                List<String> dedupedRules,
-                                                BuildIdentity identity,
-                                                ScanProfileCollector profileCollector,
-                                                ArtifactChecksumService checksumService,
-                                                H2AnalysisStoreAdapter store) {
+    private ArtifactChecksum persistAnalysisRun(AnalysisPersistence persistence, H2AnalysisStoreAdapter store) {
         try {
             store.initializeSchema();
-            store.createAnalysisRun(identity);
-            store.updateAnalysisRunStatus(identity.analysisRunId(), AnalysisRunStatus.SCANNING);
-            store.storeSourceFiles(identity.analysisRunId(), sourceFingerprint.sourceFiles());
-            store.storeMethods(identity.analysisRunId(), output.context().getMethodEntries());
-            store.storeScanEvents(identity.analysisRunId(), output.context().getEvents());
+            store.createAnalysisRun(persistence.identity());
+            store.updateAnalysisRunStatus(persistence.identity().analysisRunId(), AnalysisRunStatus.SCANNING);
+            store.storeSourceFiles(persistence.identity().analysisRunId(), persistence.sourceFingerprint().sourceFiles());
+            store.storeMethods(persistence.identity().analysisRunId(), persistence.output().context().getMethodEntries());
+            store.storeScanEvents(persistence.identity().analysisRunId(), persistence.output().context().getEvents());
             store.storeRules(
-                    identity.analysisRunId(),
-                    output.domainRules(),
-                    renderedRulesByRuleId(output.domainRules(), output.renderedRules()));
-            profileCollector.measure(ScanPhase.BTM_FILE_WRITING, () -> {
-                writeRules(request, dedupedRules, identity);
+                    persistence.identity().analysisRunId(),
+                    persistence.output().domainRules(),
+                    renderedRulesByRuleId(persistence.output().domainRules(), persistence.output().renderedRules()));
+            persistence.profileCollector().measure(ScanPhase.BTM_FILE_WRITING, () -> {
+                writeRules(persistence.request(), persistence.dedupedRules(), persistence.identity());
                 return null;
             });
-            store.updateAnalysisRunStatus(identity.analysisRunId(), AnalysisRunStatus.BTM_GENERATED);
-            ArtifactChecksum btmChecksum = checksumService.checksumFile(
-                    analysisBaseDirectory(request),
-                    request.outputFile(),
+            store.updateAnalysisRunStatus(persistence.identity().analysisRunId(), AnalysisRunStatus.BTM_GENERATED);
+            ArtifactChecksum btmChecksum = persistence.checksumService().checksumFile(
+                    analysisBaseDirectory(persistence.request()),
+                    persistence.request().outputFile(),
                     "byteman-rules");
-            store.storeArtifactChecksums(identity.analysisRunId(), List.of(btmChecksum));
-            store.updateAnalysisRunStatus(identity.analysisRunId(), AnalysisRunStatus.COMPLETED);
+            store.storeArtifactChecksums(persistence.identity().analysisRunId(), List.of(btmChecksum));
+            store.updateAnalysisRunStatus(persistence.identity().analysisRunId(), AnalysisRunStatus.COMPLETED);
             return btmChecksum;
         } catch (RuntimeException exception) {
-            markFailed(store, identity.analysisRunId());
+            markFailed(store, persistence.identity().analysisRunId());
             throw exception;
         }
     }
@@ -605,5 +599,14 @@ public final class BtmGenerationRunner {
                              List<String> renderedRules,
                              AnalysisContext context,
                              ConditionValidationReport validationReport) {
+    }
+
+    private record AnalysisPersistence(BtmGenerationRequest request,
+                                       RunOutput output,
+                                       SourceFingerprintResult sourceFingerprint,
+                                       List<String> dedupedRules,
+                                       BuildIdentity identity,
+                                       ScanProfileCollector profileCollector,
+                                       ArtifactChecksumService checksumService) {
     }
 }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/AnalyzeForensicsSemanticsTask.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/AnalyzeForensicsSemanticsTask.java
@@ -63,6 +63,7 @@ import java.util.Set;
 public abstract class AnalyzeForensicsSemanticsTask extends DefaultTask {
 
     @Inject
+    @SuppressWarnings("java:S5993")
     public AnalyzeForensicsSemanticsTask() {
         applyDefaultConventions();
     }
@@ -286,16 +287,13 @@ public abstract class AnalyzeForensicsSemanticsTask extends DefaultTask {
             if (escaped) {
                 builder.append(current);
                 escaped = false;
-                continue;
-            }
-            if (current == '\\') {
+            } else if (current == '\\') {
                 escaped = true;
-                continue;
-            }
-            if (current == '"') {
+            } else if (current == '"') {
                 return builder.toString();
+            } else {
+                builder.append(current);
             }
-            builder.append(current);
         }
         throw new GradleException("Analysis manifest has unterminated field: " + fieldName);
     }

--- a/src/main/java/de/burger/forensics/plugin/btmgen/gradle/ImportForensicsSemanticsTask.java
+++ b/src/main/java/de/burger/forensics/plugin/btmgen/gradle/ImportForensicsSemanticsTask.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 public abstract class ImportForensicsSemanticsTask extends DefaultTask {
 
     @Inject
+    @SuppressWarnings("java:S5993")
     public ImportForensicsSemanticsTask() {
         conventionIfMissing(getJoernEnabled(), false);
         if (!getJoernOutputDirectory().isPresent()) {

--- a/src/test/java/de/burger/forensics/adapters/filesystem/AnalysisManifestWriterTest.java
+++ b/src/test/java/de/burger/forensics/adapters/filesystem/AnalysisManifestWriterTest.java
@@ -64,10 +64,11 @@ class AnalysisManifestWriterTest {
                 semanticResult);
 
         String json = Files.readString(manifest);
-        assertThat(json).contains("\"joernEnabled\": true");
-        assertThat(json).contains("\"joernVersion\": \"joern 1.0\"");
-        assertThat(json).contains("\"joernFingerprint\": \"sha256:semantic\"");
-        assertThat(json).contains("\"joernArtifacts\": [");
+        assertThat(json).contains(
+                "\"joernEnabled\": true",
+                "\"joernVersion\": \"joern 1.0\"",
+                "\"joernFingerprint\": \"sha256:semantic\"",
+                "\"joernArtifacts\": [");
     }
 
     @Test

--- a/src/test/java/de/burger/forensics/adapters/joern/JoernCliSemanticAnalysisAdapterTest.java
+++ b/src/test/java/de/burger/forensics/adapters/joern/JoernCliSemanticAnalysisAdapterTest.java
@@ -41,12 +41,9 @@ class JoernCliSemanticAnalysisAdapterTest {
                 executor,
                 new JoernOutputParser(),
                 new ArtifactChecksumService());
+        SemanticAnalysisRequest request = request(sourceRoot);
 
-        SemanticAnalysisResult result = adapter.analyze(new SemanticAnalysisRequest(
-                identity(),
-                List.of(sourceRoot.toString()),
-                tempDir.resolve("workspace").toString(),
-                tempDir.resolve("joern").toString()));
+        SemanticAnalysisResult result = adapter.analyze(request);
 
         assertThat(executor.commands).hasSize(5);
         assertThat(result.providerVersion()).isEqualTo("joern 1.2.3");
@@ -67,12 +64,9 @@ class JoernCliSemanticAnalysisAdapterTest {
                 executor,
                 new JoernOutputParser(),
                 new ArtifactChecksumService());
+        SemanticAnalysisRequest request = request(sourceRoot);
 
-        assertThatThrownBy(() -> adapter.analyze(new SemanticAnalysisRequest(
-                identity(),
-                List.of(sourceRoot.toString()),
-                tempDir.resolve("workspace").toString(),
-                tempDir.resolve("joern").toString())))
+        assertThatThrownBy(() -> adapter.analyze(request))
                 .isInstanceOf(JoernAnalysisException.class)
                 .hasMessageContaining("joern-parse");
     }
@@ -87,12 +81,9 @@ class JoernCliSemanticAnalysisAdapterTest {
                 executor,
                 new JoernOutputParser(),
                 new ArtifactChecksumService());
+        SemanticAnalysisRequest request = request(sourceRoot);
 
-        SemanticAnalysisResult result = adapter.analyze(new SemanticAnalysisRequest(
-                identity(),
-                List.of(sourceRoot.toString()),
-                tempDir.resolve("workspace").toString(),
-                tempDir.resolve("joern").toString()));
+        SemanticAnalysisResult result = adapter.analyze(request);
 
         assertThat(result.providerVersion()).isEqualTo("joern 1.2.3");
     }
@@ -108,12 +99,9 @@ class JoernCliSemanticAnalysisAdapterTest {
                 executor,
                 new JoernOutputParser(),
                 new ArtifactChecksumService());
+        SemanticAnalysisRequest request = request(sourceRoot);
 
-        SemanticAnalysisResult result = adapter.analyze(new SemanticAnalysisRequest(
-                identity(),
-                List.of(sourceRoot.toString()),
-                tempDir.resolve("workspace").toString(),
-                tempDir.resolve("joern").toString()));
+        SemanticAnalysisResult result = adapter.analyze(request);
 
         assertThat(result.providerVersion()).isEqualTo("UNKNOWN");
         assertThat(Files.readString(tempDir.resolve("joern/slices.json"))).contains("\"anchors\":[]");
@@ -126,6 +114,14 @@ class JoernCliSemanticAnalysisAdapterTest {
                 Path.of("joern-slice"),
                 Duration.ofSeconds(30),
                 failOnError);
+    }
+
+    private SemanticAnalysisRequest request(Path sourceRoot) {
+        return new SemanticAnalysisRequest(
+                identity(),
+                List.of(sourceRoot.toString()),
+                tempDir.resolve("workspace").toString(),
+                tempDir.resolve("joern").toString());
     }
 
     private static BuildIdentity identity() {

--- a/src/test/java/de/burger/forensics/adaptersupport/joern/JoernOutputParserTest.java
+++ b/src/test/java/de/burger/forensics/adaptersupport/joern/JoernOutputParserTest.java
@@ -10,6 +10,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -96,7 +98,7 @@ class JoernOutputParserTest {
                 {"nodes":[{"id":"n1","type":"CALL","file":"Demo.java","line":1}]}
                 """, StandardCharsets.UTF_8);
 
-        assertThatThrownBy(() -> new JoernOutputParser().parse(paths, List.of(), "joern", "sha256:x"))
+        assertThatThrownBy(() -> parse(paths, "joern", "sha256:x"))
                 .isInstanceOf(JoernAnalysisException.class)
                 .hasMessageContaining("method");
     }
@@ -108,13 +110,13 @@ class JoernOutputParserTest {
                 {"nodes":[{"id":"n1","type":"CALL","file":"Demo.java","method":"run","line":1.5,"code":"call()"}]}
                 """, StandardCharsets.UTF_8);
 
-        assertThatThrownBy(() -> new JoernOutputParser().parse(paths, List.of(), "joern", "sha256:x"))
+        assertThatThrownBy(() -> parse(paths, "joern", "sha256:x"))
                 .isInstanceOf(NumberFormatException.class);
 
         Files.writeString(paths.callgraph(), """
                 {"nodes":[{"id":"n1","type":"CALL","file":"Demo.java","method":"run","line":,"code":"call()"}]}
                 """, StandardCharsets.UTF_8);
-        assertThatThrownBy(() -> new JoernOutputParser().parse(paths, List.of(), "joern", "sha256:x"))
+        assertThatThrownBy(() -> parse(paths, "joern", "sha256:x"))
                 .isInstanceOf(JoernAnalysisException.class)
                 .hasMessageContaining("line");
     }
@@ -126,7 +128,7 @@ class JoernOutputParserTest {
                 {"nodes":[{"id":"n1","type":"CALL","file":"Demo.java","line":1,"code":"call()","method":run}]}
                 """, StandardCharsets.UTF_8);
 
-        assertThatThrownBy(() -> new JoernOutputParser().parse(paths, List.of(), "joern", "sha256:x"))
+        assertThatThrownBy(() -> parse(paths, "joern", "sha256:x"))
                 .isInstanceOf(JoernAnalysisException.class)
                 .hasMessageContaining("method");
     }
@@ -151,46 +153,34 @@ class JoernOutputParserTest {
                 Duration.ofSeconds(1),
                 true);
         JoernArtifactPaths paths = JoernArtifactPaths.under(tempDir);
+        Path joern = Path.of("joern");
+        Path joernParse = Path.of("joern-parse");
+        Path joernSlice = Path.of("joern-slice");
+        Duration oneSecond = Duration.ofSeconds(1);
+        Duration negativeDuration = Duration.ofSeconds(-1);
 
         assertThat(config.failOnError()).isTrue();
         assertThat(paths.all()).containsExactly(paths.cpg(), paths.callgraph(), paths.controlflow(), paths.dataflow(), paths.slices());
-        assertThatThrownBy(() -> new JoernAnalysisConfig(
-                null,
-                Path.of("joern-parse"),
-                Path.of("joern-slice"),
-                Duration.ofSeconds(1),
-                true)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new JoernAnalysisConfig(
-                Path.of("joern"),
-                null,
-                Path.of("joern-slice"),
-                Duration.ofSeconds(1),
-                true)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new JoernAnalysisConfig(
-                Path.of("joern"),
-                Path.of("joern-parse"),
-                null,
-                Duration.ofSeconds(1),
-                true)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new JoernAnalysisConfig(
-                Path.of("joern"),
-                Path.of("joern-parse"),
-                Path.of("joern-slice"),
-                Duration.ZERO,
-                true)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new JoernAnalysisConfig(
-                Path.of("joern"),
-                Path.of("joern-parse"),
-                Path.of("joern-slice"),
-                Duration.ofSeconds(-1),
-                true)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> JoernArtifactPaths.under(null))
+        assertThatThrownBy(() -> config(null, joernParse, joernSlice, oneSecond))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> config(joern, null, joernSlice, oneSecond))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> config(joern, joernParse, null, oneSecond))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> config(joern, joernParse, joernSlice, Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> config(joern, joernParse, joernSlice, negativeDuration))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> artifactPaths(null))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void processExecutorRejectsEmptyCommands() {
-        assertThatThrownBy(() -> new ProcessJoernCommandExecutor().execute(List.of(), Duration.ofSeconds(1), tempDir))
+        List<String> command = List.of();
+        Duration timeout = Duration.ofSeconds(1);
+
+        assertThatThrownBy(() -> execute(command, timeout, tempDir))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -209,10 +199,11 @@ class JoernOutputParserTest {
 
     @Test
     void processExecutorWrapsMissingCommandFailures() {
-        assertThatThrownBy(() -> new ProcessJoernCommandExecutor().execute(
-                List.of(tempDir.resolve("missing-command").toString()),
-                Duration.ofSeconds(1),
-                tempDir)).isInstanceOf(IllegalStateException.class)
+        List<String> command = List.of(tempDir.resolve("missing-command").toString());
+        Duration timeout = Duration.ofSeconds(1);
+
+        assertThatThrownBy(() -> execute(command, timeout, tempDir))
+                .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Failed to execute Joern command");
     }
 
@@ -237,9 +228,28 @@ class JoernOutputParserTest {
         return System.getProperty("os.name").toLowerCase(java.util.Locale.ROOT).contains("win");
     }
 
+    private static SemanticAnalysisResult parse(JoernArtifactPaths paths, String providerVersion, String semanticFingerprint) {
+        return new JoernOutputParser().parse(paths, List.of(), providerVersion, semanticFingerprint);
+    }
+
+    private static JoernAnalysisConfig config(Path joernExecutable,
+                                              Path joernParseExecutable,
+                                              Path joernSliceExecutable,
+                                              Duration timeout) {
+        return new JoernAnalysisConfig(joernExecutable, joernParseExecutable, joernSliceExecutable, timeout, true);
+    }
+
+    private static JoernArtifactPaths artifactPaths(Path root) {
+        return JoernArtifactPaths.under(root);
+    }
+
+    private static JoernCommandResult execute(List<String> command, Duration timeout, Path workingDirectory) {
+        return new ProcessJoernCommandExecutor().execute(command, timeout, workingDirectory);
+    }
+
     public static final class SleepProcess {
         public static void main(String[] args) throws Exception {
-            Thread.sleep(10_000L);
+            new CountDownLatch(1).await(10L, TimeUnit.SECONDS);
         }
     }
 }

--- a/src/test/java/de/burger/forensics/application/service/AnalyzeSemanticsUseCaseTest.java
+++ b/src/test/java/de/burger/forensics/application/service/AnalyzeSemanticsUseCaseTest.java
@@ -43,8 +43,9 @@ class AnalyzeSemanticsUseCaseTest {
         RecordingStore store = new RecordingStore();
         store.failGraph = true;
         AnalyzeSemanticsUseCase useCase = new AnalyzeSemanticsUseCase(request -> result, store);
+        SemanticAnalysisRequest request = request();
 
-        assertThatThrownBy(() -> useCase.analyze(request()))
+        assertThatThrownBy(() -> useCase.analyze(request))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("store failed");
         assertThat(store.calls).containsExactly("create", "graph", "status:FAILED");
@@ -100,12 +101,13 @@ class AnalyzeSemanticsUseCaseTest {
     void useCaseRejectsNullDependenciesAndRequest() {
         SemanticAnalysisPort analysisPort = request -> result(List.of());
         RecordingStore store = new RecordingStore();
+        AnalyzeSemanticsUseCase useCase = new AnalyzeSemanticsUseCase(analysisPort, store);
 
         assertThatThrownBy(() -> new AnalyzeSemanticsUseCase(null, store))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new AnalyzeSemanticsUseCase(analysisPort, null))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new AnalyzeSemanticsUseCase(analysisPort, store).analyze(null))
+        assertThatThrownBy(() -> useCase.analyze(null))
                 .isInstanceOf(NullPointerException.class);
     }
 

--- a/src/test/java/de/burger/forensics/domain/model/semantic/SemanticAnalysisModelTest.java
+++ b/src/test/java/de/burger/forensics/domain/model/semantic/SemanticAnalysisModelTest.java
@@ -19,6 +19,8 @@ class SemanticAnalysisModelTest {
     @Test
     void requestRequiresIdentitySourcesAndDirectories() {
         BuildIdentity identity = identity();
+        List<String> emptySources = List.of();
+        List<String> blankSources = List.of(" ");
 
         SemanticAnalysisRequest request = new SemanticAnalysisRequest(
                 identity,
@@ -28,19 +30,19 @@ class SemanticAnalysisModelTest {
 
         assertThat(request.identity()).isEqualTo(identity);
         assertThat(request.sourceRoots()).containsExactly("src/main/java");
-        assertThatThrownBy(() -> new SemanticAnalysisRequest(null, List.of("src"), "work", "out"))
+        assertThatThrownBy(() -> requestWithIdentity(null))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new SemanticAnalysisRequest(identity, List.of(), "work", "out"))
+        assertThatThrownBy(() -> requestWithSources(emptySources))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnalysisRequest(identity, List.of(" "), "work", "out"))
+        assertThatThrownBy(() -> requestWithSources(blankSources))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnalysisRequest(identity, List.of("src"), null, "out"))
+        assertThatThrownBy(() -> requestWithWorkspace(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnalysisRequest(identity, List.of("src"), " ", "out"))
+        assertThatThrownBy(() -> requestWithWorkspace(" "))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnalysisRequest(identity, List.of("src"), "work", null))
+        assertThatThrownBy(() -> requestWithOutputDirectory(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnalysisRequest(identity, List.of("src"), "work", " "))
+        assertThatThrownBy(() -> requestWithOutputDirectory(" "))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -61,39 +63,12 @@ class SemanticAnalysisModelTest {
 
         assertThat(result.artifacts()).containsExactly(artifact);
         assertThat(result.nodes()).containsExactly(node());
-        assertThatThrownBy(() -> new SemanticAnalysisResult(
-                null,
-                "sha256:x",
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of())).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnalysisResult(
-                " ",
-                "sha256:x",
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of())).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnalysisResult(
-                "joern",
-                null,
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of(),
-                List.of())).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> resultWithProviderVersion(null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> resultWithProviderVersion(" "))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> resultWithFingerprint(null))
+                .isInstanceOf(IllegalArgumentException.class);
         assertThat(SemanticAnalysisResult.empty("UNKNOWN", "sha256:empty").nodes()).isEmpty();
     }
 
@@ -107,33 +82,33 @@ class SemanticAnalysisModelTest {
         assertThat(dataFlowStep().orderIndex()).isZero();
         assertThat(dataFlowPath().steps()).containsExactly(dataFlowStep());
 
-        assertThatThrownBy(() -> new SemanticNode(" ", "CALL", "Demo.java", "Demo", "run", null, 1, null))
+        assertThatThrownBy(() -> nodeWithId(" "))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticNode("n1", null, "Demo.java", "Demo", "run", null, 1, null))
+        assertThatThrownBy(() -> nodeWithType(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticNode("n1", "CALL", null, "Demo", "run", null, 1, null))
+        assertThatThrownBy(() -> nodeWithFile(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticNode("n1", "CALL", "Demo.java", "Demo", " ", null, 1, null))
+        assertThatThrownBy(() -> nodeWithMethod(" "))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticNode("n1", "CALL", "Demo.java", "Demo", "run", null, 0, null))
+        assertThatThrownBy(() -> nodeWithLine(0))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticEdge(null, "n1", "n2", "CALL"))
+        assertThatThrownBy(() -> edgeWithId(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticEdge("e1", " ", "n2", "CALL"))
+        assertThatThrownBy(() -> edgeWithSource(" "))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticEdge("e1", "n1", null, "CALL"))
+        assertThatThrownBy(() -> edgeWithTarget(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticEdge("e1", "n1", "n2", " "))
+        assertThatThrownBy(() -> edgeWithType(" "))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticMethod(" ", "Demo.java", "Demo", "run", null, 1))
+        assertThatThrownBy(() -> methodWithId(" "))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticMethod("m1", null, "Demo", "run", null, 1))
+        assertThatThrownBy(() -> methodWithFile(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticMethod("m1", "Demo.java", " ", "run", null, 1))
+        assertThatThrownBy(() -> methodWithClassName(" "))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticMethod("m1", "Demo.java", "Demo", null, null, 1))
+        assertThatThrownBy(() -> methodWithName(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticMethod("m1", "Demo.java", "Demo", "run", null, 0))
+        assertThatThrownBy(() -> methodWithLine(0))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -152,46 +127,202 @@ class SemanticAnalysisModelTest {
                 0.40d,
                 "LINE_ONLY").normalizedCode()).isEmpty();
 
-        assertThatThrownBy(() -> new CallRelation(null, "m2", "n1"))
+        assertThatThrownBy(() -> callWithCaller(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new CallRelation("m1", " ", "n1"))
+        assertThatThrownBy(() -> callWithCallee(" "))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new CallRelation("m1", "m2", null))
+        assertThatThrownBy(() -> callWithNode(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new ControlFlowRelation(null, "n2", "NEXT"))
+        assertThatThrownBy(() -> controlFlowWithSource(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new ControlFlowRelation("n1", " ", "NEXT"))
+        assertThatThrownBy(() -> controlFlowWithTarget(" "))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new ControlFlowRelation("n1", "n2", null))
+        assertThatThrownBy(() -> controlFlowWithType(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new DataFlowStep(null, 0, "SOURCE"))
+        assertThatThrownBy(() -> dataFlowStepWithNode(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new DataFlowStep("n1", -1, "SOURCE"))
+        assertThatThrownBy(() -> dataFlowStepWithOrder(-1))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new DataFlowStep("n1", 0, " "))
+        assertThatThrownBy(() -> dataFlowStepWithKind(" "))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new DataFlowPath(null, "n1", "n2", List.of()))
+        assertThatThrownBy(() -> dataFlowPathWithId(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new DataFlowPath("p1", " ", "n2", List.of()))
+        assertThatThrownBy(() -> dataFlowPathWithSource(" "))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new DataFlowPath("p1", "n1", null, List.of()))
+        assertThatThrownBy(() -> dataFlowPathWithTarget(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnchor(null, "n1", "Demo.java", "Demo", "run", null, 1, null, 0.1d, "LINE_ONLY"))
+        assertThatThrownBy(() -> anchorWithEventKey(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnchor("event", null, "Demo.java", "Demo", "run", null, 1, null, 0.1d, "LINE_ONLY"))
+        assertThatThrownBy(() -> anchorWithNode(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnchor("event", "n1", null, "Demo", "run", null, 1, null, 0.1d, "LINE_ONLY"))
+        assertThatThrownBy(() -> anchorWithFile(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnchor("event", "n1", "Demo.java", "Demo", null, null, 1, null, 0.1d, "LINE_ONLY"))
+        assertThatThrownBy(() -> anchorWithMethod(null))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnchor("event", "n1", "Demo.java", "Demo", "run", null, 0, null, 0.1d, "LINE_ONLY"))
+        assertThatThrownBy(() -> anchorWithLine(0))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnchor("event", "n1", "Demo.java", "Demo", "run", null, 1, null, -0.1d, "LINE_ONLY"))
+        assertThatThrownBy(() -> anchorWithConfidence(-0.1d))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnchor("event", "n1", "Demo.java", "Demo", "run", null, 1, null, 1.1d, "LINE_ONLY"))
+        assertThatThrownBy(() -> anchorWithConfidence(1.1d))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new SemanticAnchor("event", "n1", "Demo.java", "Demo", "run", null, 1, null, 0.1d, null))
+        assertThatThrownBy(() -> anchorWithStrategy(null))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static SemanticAnalysisRequest requestWithIdentity(BuildIdentity identity) {
+        return new SemanticAnalysisRequest(identity, List.of("src"), "work", "out");
+    }
+
+    private static SemanticAnalysisRequest requestWithSources(List<String> sourceRoots) {
+        return new SemanticAnalysisRequest(identity(), sourceRoots, "work", "out");
+    }
+
+    private static SemanticAnalysisRequest requestWithWorkspace(String workspaceDirectory) {
+        return new SemanticAnalysisRequest(identity(), List.of("src"), workspaceDirectory, "out");
+    }
+
+    private static SemanticAnalysisRequest requestWithOutputDirectory(String outputDirectory) {
+        return new SemanticAnalysisRequest(identity(), List.of("src"), "work", outputDirectory);
+    }
+
+    private static SemanticAnalysisResult resultWithProviderVersion(String providerVersion) {
+        return SemanticAnalysisResult.empty(providerVersion, "sha256:x");
+    }
+
+    private static SemanticAnalysisResult resultWithFingerprint(String semanticFingerprint) {
+        return SemanticAnalysisResult.empty("joern", semanticFingerprint);
+    }
+
+    private static SemanticNode nodeWithId(String nodeId) {
+        return new SemanticNode(nodeId, "CALL", "Demo.java", "Demo", "run", null, 1, null);
+    }
+
+    private static SemanticNode nodeWithType(String nodeType) {
+        return new SemanticNode("n1", nodeType, "Demo.java", "Demo", "run", null, 1, null);
+    }
+
+    private static SemanticNode nodeWithFile(String filePath) {
+        return new SemanticNode("n1", "CALL", filePath, "Demo", "run", null, 1, null);
+    }
+
+    private static SemanticNode nodeWithMethod(String methodName) {
+        return new SemanticNode("n1", "CALL", "Demo.java", "Demo", methodName, null, 1, null);
+    }
+
+    private static SemanticNode nodeWithLine(int line) {
+        return new SemanticNode("n1", "CALL", "Demo.java", "Demo", "run", null, line, null);
+    }
+
+    private static SemanticEdge edgeWithId(String edgeId) {
+        return new SemanticEdge(edgeId, "n1", "n2", "CALL");
+    }
+
+    private static SemanticEdge edgeWithSource(String sourceNodeId) {
+        return new SemanticEdge("e1", sourceNodeId, "n2", "CALL");
+    }
+
+    private static SemanticEdge edgeWithTarget(String targetNodeId) {
+        return new SemanticEdge("e1", "n1", targetNodeId, "CALL");
+    }
+
+    private static SemanticEdge edgeWithType(String edgeType) {
+        return new SemanticEdge("e1", "n1", "n2", edgeType);
+    }
+
+    private static SemanticMethod methodWithId(String methodId) {
+        return new SemanticMethod(methodId, "Demo.java", "Demo", "run", null, 1);
+    }
+
+    private static SemanticMethod methodWithFile(String filePath) {
+        return new SemanticMethod("m1", filePath, "Demo", "run", null, 1);
+    }
+
+    private static SemanticMethod methodWithClassName(String className) {
+        return new SemanticMethod("m1", "Demo.java", className, "run", null, 1);
+    }
+
+    private static SemanticMethod methodWithName(String methodName) {
+        return new SemanticMethod("m1", "Demo.java", "Demo", methodName, null, 1);
+    }
+
+    private static SemanticMethod methodWithLine(int line) {
+        return new SemanticMethod("m1", "Demo.java", "Demo", "run", null, line);
+    }
+
+    private static CallRelation callWithCaller(String callerMethodId) {
+        return new CallRelation(callerMethodId, "m2", "n1");
+    }
+
+    private static CallRelation callWithCallee(String calleeMethodId) {
+        return new CallRelation("m1", calleeMethodId, "n1");
+    }
+
+    private static CallRelation callWithNode(String callNodeId) {
+        return new CallRelation("m1", "m2", callNodeId);
+    }
+
+    private static ControlFlowRelation controlFlowWithSource(String sourceNodeId) {
+        return new ControlFlowRelation(sourceNodeId, "n2", "NEXT");
+    }
+
+    private static ControlFlowRelation controlFlowWithTarget(String targetNodeId) {
+        return new ControlFlowRelation("n1", targetNodeId, "NEXT");
+    }
+
+    private static ControlFlowRelation controlFlowWithType(String relationType) {
+        return new ControlFlowRelation("n1", "n2", relationType);
+    }
+
+    private static DataFlowStep dataFlowStepWithNode(String nodeId) {
+        return new DataFlowStep(nodeId, 0, "SOURCE");
+    }
+
+    private static DataFlowStep dataFlowStepWithOrder(int orderIndex) {
+        return new DataFlowStep("n1", orderIndex, "SOURCE");
+    }
+
+    private static DataFlowStep dataFlowStepWithKind(String stepKind) {
+        return new DataFlowStep("n1", 0, stepKind);
+    }
+
+    private static DataFlowPath dataFlowPathWithId(String pathId) {
+        return new DataFlowPath(pathId, "n1", "n2", List.of());
+    }
+
+    private static DataFlowPath dataFlowPathWithSource(String sourceNodeId) {
+        return new DataFlowPath("p1", sourceNodeId, "n2", List.of());
+    }
+
+    private static DataFlowPath dataFlowPathWithTarget(String targetNodeId) {
+        return new DataFlowPath("p1", "n1", targetNodeId, List.of());
+    }
+
+    private static SemanticAnchor anchorWithEventKey(String scanEventKey) {
+        return new SemanticAnchor(scanEventKey, "n1", "Demo.java", "Demo", "run", null, 1, null, 0.1d, "LINE_ONLY");
+    }
+
+    private static SemanticAnchor anchorWithNode(String semanticNodeId) {
+        return new SemanticAnchor("event", semanticNodeId, "Demo.java", "Demo", "run", null, 1, null, 0.1d, "LINE_ONLY");
+    }
+
+    private static SemanticAnchor anchorWithFile(String filePath) {
+        return new SemanticAnchor("event", "n1", filePath, "Demo", "run", null, 1, null, 0.1d, "LINE_ONLY");
+    }
+
+    private static SemanticAnchor anchorWithMethod(String methodName) {
+        return new SemanticAnchor("event", "n1", "Demo.java", "Demo", methodName, null, 1, null, 0.1d, "LINE_ONLY");
+    }
+
+    private static SemanticAnchor anchorWithLine(int line) {
+        return new SemanticAnchor("event", "n1", "Demo.java", "Demo", "run", null, line, null, 0.1d, "LINE_ONLY");
+    }
+
+    private static SemanticAnchor anchorWithConfidence(double confidence) {
+        return new SemanticAnchor("event", "n1", "Demo.java", "Demo", "run", null, 1, null, confidence, "LINE_ONLY");
+    }
+
+    private static SemanticAnchor anchorWithStrategy(String matchStrategy) {
+        return new SemanticAnchor("event", "n1", "Demo.java", "Demo", "run", null, 1, null, 0.1d, matchStrategy);
     }
 
     private static BuildIdentity identity() {

--- a/src/test/java/de/burger/forensics/plugin/btmgen/gradle/AnalyzeForensicsSemanticsTaskTest.java
+++ b/src/test/java/de/burger/forensics/plugin/btmgen/gradle/AnalyzeForensicsSemanticsTaskTest.java
@@ -116,8 +116,9 @@ class AnalyzeForensicsSemanticsTaskTest {
         task.analyze();
 
         String manifestJson = Files.readString(manifest);
-        assertThat(manifestJson).contains("\"joernEnabled\": true");
-        assertThat(manifestJson).contains("\"joernFingerprint\": \"sha256:semantic\"");
+        assertThat(manifestJson).contains(
+                "\"joernEnabled\": true",
+                "\"joernFingerprint\": \"sha256:semantic\"");
         assertThat(Files.readString(checksums)).contains("joern/cpg.bin");
         assertThat(rowCount(database, "joern_import_run")).isEqualTo(1);
         assertThat(rowCount(database, "semantic_anchor")).isEqualTo(1);


### PR DESCRIPTION
## Summary
- resolve the refreshed SonarCloud OPEN findings for Joern semantic analysis code and tests
- group BTM persistence inputs to avoid the long parameter list
- remove duplicated Joern JSON field literals and simplify parser loop control
- keep Gradle task constructors public with targeted `java:S5993` suppressions because Gradle cannot instantiate these tasks with protected constructors in this project
- reshape throwing assertions and AssertJ chains in semantic and Joern tests

## Verification
- `./gradlew.bat compileJava compileTestJava --console=plain --stacktrace`
- `./gradlew.bat test --tests de.burger.forensics.adapters.filesystem.AnalysisManifestWriterTest --tests de.burger.forensics.adapters.joern.JoernCliSemanticAnalysisAdapterTest --tests de.burger.forensics.adaptersupport.joern.JoernOutputParserTest --tests de.burger.forensics.application.service.AnalyzeSemanticsUseCaseTest --tests de.burger.forensics.domain.model.semantic.SemanticAnalysisModelTest --tests de.burger.forensics.plugin.btmgen.gradle.AnalyzeForensicsSemanticsTaskTest --tests de.burger.forensics.plugin.btmgen.gradle.GenerateBtmTaskTest --tests de.burger.forensics.plugin.btmgen.common.BtmGenerationAdapterValidationTest --console=plain --stacktrace`
- `./gradlew.bat clean test jacocoTestReport jacocoTestCoverageVerification checkPackageCoverage --console=plain --stacktrace`
- `./gradlew.bat validatePlugins --no-daemon --console=plain --stacktrace`
- `wsl.exe bash -lc "cd /mnt/d/Projects/forensics_tracing && ./gradlew clean test jacocoTestReport jacocoTestCoverageVerification checkPackageCoverage --console=plain --stacktrace"`